### PR TITLE
refactor: Revert project placeholders to Material Symbols

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,12 +151,16 @@
             <h2>Key Projects</h2>
             <div class="container">
                 <article>
-                    <img src="https://via.placeholder.com/350x200/161B22/8B949E?text=Project+1:+AWS+to+GCP" alt="Project 1 Placeholder Image" class="project-image">
+                    <div class="project-image-placeholder">
+                        <span class="material-symbols-outlined">cloud_sync</span>
+                    </div>
                     <h4>1. AWS to GCP Databricks Workload Migration & Optimization (NRG Energy)</h4>
                     <p>Orchestrated the architectural design and strategic execution of migrating complex enterprise Databricks workloads from AWS to Google Cloud Platform (GCP). This initiative involved a comprehensive re-architecture of the data lake on Google Cloud Storage (GCS), optimization of data processing pipelines using GCP-native services like Dataproc and BigQuery, and the establishment of robust data governance and security frameworks. Key responsibilities included a comprehensive re-architecture of the data lake on Google Cloud Storage (GCS) for enhanced scalability and cost-efficiency; optimization of Spark-based data processing pipelines by leveraging GCP-native services such as Dataproc for managed Spark and BigQuery for advanced serverless analytics, significantly improving performance and reducing operational overhead. Engineered and implemented optimized, secure networking solutions, including VPC Peering and Private Google Access, to facilitate seamless and protected data flow between on-premises systems, AWS, and GCP. This strategic migration not only resulted in a 20% reduction in data storage costs but also enhanced data processing speeds by an average of 25%, empowering NRG with a more agile and cost-effective data infrastructure.</p>
                 </article>
                 <article>
-                    <img src="https://via.placeholder.com/350x200/161B22/8B949E?text=Project+2:+Data+Analytics+Platform" alt="Project 2 Placeholder Image" class="project-image">
+                    <div class="project-image-placeholder">
+                        <span class="material-symbols-outlined">insights</span>
+                    </div>
                     <h4>2. Design of a Scalable & Secure Data Analytics Platform on GCP (Conceptual/Representative Project for Legacy Modernization)</h4>
                     <p>Architected a modern, cloud-native data analytics platform on Google Cloud Platform (GCP) tailored for enterprises looking to modernize their legacy data systems. This conceptual project showcases a blueprint for building a highly scalable, secure, and performant data ecosystem capable of handling diverse data types and advanced analytics workloads. The comprehensive architecture featured Google BigQuery for scalable enterprise data warehousing, enabling complex analytical queries over large datasets; Google Dataflow for stream and batch data processing, providing a serverless and auto-scaling ETL solution; and Google Dataproc for managed Spark and Hadoop services, facilitating big data processing and machine learning tasks. Leveraged Google Cloud Storage (GCS) for a flexible, multi-tiered data lake strategy, accommodating raw, processed, and curated data. Focused on defining and implementing best practices for data governance, security (including IAM, encryption, and network controls), and operational monitoring using Google Cloud's operations suite, ensuring a robust and compliant platform.</p>
                 </article>

--- a/style.css
+++ b/style.css
@@ -380,23 +380,23 @@ a:hover, a:focus {
     /* font-size: 48px; REMOVED - Handled by specific rules */
 }
 
-.project-image-placeholder .material-symbols-outlined {
-    color: var(--app-accent-color-2); /* Project icons use Accent 2 */
-    font-size: 48px; /* Ensure size is maintained if not inherited correctly */
+/* Removed .project-image rule */
+
+.project-image-placeholder {
+    width: 100%;
+    height: 100px; /* Adjusted height for icon display */
+    background-color: transparent; /* Cleaner look, no separate background for the placeholder div */
+    border-radius: 8px; /* Consistent with other card elements */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 20px; /* Space below icon placeholder */
 }
 
-/* Removed .project-image-placeholder and .project-image-placeholder .material-symbols-outlined rules */
-
-.project-image {
-    display: block; /* Remove extra space below image */
-    width: 100%;    /* Make image responsive within its container */
-    max-width: 350px; /* Optional: Set a max-width if you don't want it to exceed placeholder size */
-    height: auto;   /* Maintain aspect ratio */
-    border-radius: 8px; /* Match card styling */
-    margin-bottom: 20px; /* Space below image */
-    object-fit: cover; /* Ensure image covers the area if aspect ratios differ */
-    margin-left: auto; /* Center the image if article is wider */
-    margin-right: auto; /* Center the image if article is wider */
+.project-image-placeholder .material-symbols-outlined {
+    font-size: 56px; /* Larger icon size */
+    color: var(--app-accent-color-2); /* Using Accent Color 2 (Orange/Amber) */
+    /* Base styles like font-family, display: inline-block are inherited from the general .material-symbols-outlined rule */
 }
 
 /* Keyframes for animations */


### PR DESCRIPTION
This commit reverts the project placeholders from `https://via.placeholder.com` images back to using Material Symbols icons. This change addresses issues with the external images not loading and aligns with your preference for an icon-based representation.

Key changes:
- HTML: Replaced `<img>` tags in the project sections with `div.project-image-placeholder` elements containing `<span>` tags for Material Symbols.
  - Project 1 now uses the 'cloud_sync' icon.
  - Project 2 now uses the 'insights' icon.
- CSS:
  - Removed the `.project-image` CSS rule previously used for styling the `<img>` tags.
  - Re-added and updated CSS rules for `.project-image-placeholder` and `.project-image-placeholder .material-symbols-outlined` to style the new icons, including setting their size and using Accent Color 2 (Orange/Amber).

This change ensures a consistent, internally managed visual representation for project placeholders.