### PR TITLE
fix: Adjust spacing, resolve overlaps, and add GitHub link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,7 @@
     <header>
         <div class="container">
             <h1 class="animated-name" aria-label="Jagadeesh Thiruveedula">
-                <span class="char">J</span><span class="char">a</span><span class="char">g</span><span class="char">a</span><span class="char">d</span><span class="char">e</span><span class="char">e</span><span class="char">s</span><span class="char">h</span>
-                <span class="char space"> </span>
-                <span class="char">T</span><span class="char">h</span><span class="char">i</span><span class="char">r</span><span class="char">u</span><span class="char">v</span><span class="char">e</span><span class="char">e</span><span class="char">d</span><span class="char">u</span><span class="char">l</span><span class="char">a</span>
+                <span class="char">J</span><span class="char">a</span><span class="char">g</span><span class="char">a</span><span class="char">d</span><span class="char">e</span><span class="char">e</span><span class="char">s</span><span class="char">h</span><span class="char space"> </span><span class="char">T</span><span class="char">h</span><span class="char">i</span><span class="char">r</span><span class="char">u</span><span class="char">v</span><span class="char">e</span><span class="char">e</span><span class="char">d</span><span class="char">u</span><span class="char">l</span><span class="char">a</span>
             </h1>
             <div class="tagline-container">
                 <span class="tagline-pill tagline-pill-architect">Associate Architect</span>
@@ -224,6 +222,7 @@
                     <h2>Connect with Me</h2>
                     <ul>
                         <li><a href="https://www.linkedin.com/in/jagadeesh-thiruveedula" target="_blank" rel="noopener noreferrer" class="button button-filled">LinkedIn</a></li>
+                        <li><a href="https://github.com/jthiruveedula" target="_blank" rel="noopener noreferrer" class="button button-filled">GitHub</a></li>
                         <li><a href="https://medium.com/@tjagadeesh77" target="_blank" rel="noopener noreferrer" class="button button-filled">Medium</a></li>
                         <li><a href="https://docs.microsoft.com/en-us/users/jagadeeshthiruveedula77/" target="_blank" rel="noopener noreferrer" class="button button-filled">MS Learn Profile</a></li>
                     </ul>

--- a/style.css
+++ b/style.css
@@ -163,7 +163,7 @@ body::after {
 header {
     background: var(--md-sys-color-surface); /* Using surface for a slightly distinct header background */
     color: var(--md-sys-color-on-surface);
-    padding: 25px 0; /* Consistent padding */
+    padding: 25px 0 40px 0; /* Increased bottom padding */
     border-bottom: 1px solid var(--md-sys-color-outline); /* Subtle separator */
     text-align: center;
     transition: background-color 0.3s ease, color 0.3s ease, border-bottom-color 0.3s ease;
@@ -337,7 +337,7 @@ main section h2, main section h3 {
     border-bottom-color: var(--md-sys-color-outline); 
     padding-bottom: 10px; /* Space from text to border */
     border-bottom: 1px solid var(--md-sys-color-outline); 
-    margin-bottom: 16px; /* Overrides general h_ margin-bottom to ensure space is AFTER border+padding */
+    margin-bottom: 24px; /* Increased margin to prevent overlap with animated content below */
 }
 
 /* Styling for paragraphs directly following an h3 (like "Primary Expertise: GCP") */


### PR DESCRIPTION
This commit addresses your feedback regarding visual spacing and adds a GitHub profile link.

Key changes:

- **Name Spacing:** I corrected a double space issue in the animated name by removing extraneous whitespace between inline-block span elements in the HTML.
- **Layout Adjustments:**
    - I increased header bottom padding to create more separation between the header animation and main section content.
    - I increased bottom margin for section headings (h2, h3) that have a bottom border to prevent visual overlap from animating content in subsequent sections.
- **Contact Section:** I added your GitHub profile (https://github.com/jthiruveedula) to the "Connect with Me" card, styled consistently with other social media links.