### PR TITLE
fix: Ensure Experience section container is visible for timeline anim…

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,9 +31,15 @@ document.addEventListener('DOMContentLoaded', () => {
     sections.forEach(section => {
         const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         if (!prefersReducedMotion) {
-            section.style.opacity = '0';
+            if (section.id !== 'experience') {
+                section.style.opacity = '0';
+            } else {
+                // Ensure the #experience section container itself is visible,
+                // as its children (timeline-item) will be animated individually.
+                section.style.opacity = '1';
+            }
         } else {
-            section.style.opacity = '1';
+            section.style.opacity = '1'; // All sections visible if reduced motion
         }
     });
 


### PR DESCRIPTION
…ations

I corrected an issue where the #experience section container itself was being set to opacity: 0 by the general section animation setup, preventing the timeline items within from being visible.

The script.js has been modified so that the #experience section container now explicitly has its opacity set to 1, allowing the timelineObserver to correctly handle the animation and visibility of its child .timeline-item elements.