### PR TITLE
Add redesign plan for GenAI-Driven Data Architect portfolio

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,50 @@
+name: PR Preview Build
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-preview-${{ github.event.pull_request.number }}
+          path: dist
+          retention-days: 14
+
+      - name: Comment preview link on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.runId;
+            const repo = context.repo;
+            const artifactUrl = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
+            const body = `✅ **PR Preview build succeeded.**\n\nDownload the built site artifact (\`site-preview-${context.issue.number}\`) from the workflow run: ${artifactUrl}\n\nUnzip and serve locally:\n\`\`\`bash\nnpx serve dist\n\`\`\`\nProduction deploy runs automatically on merge to \`master\` via \`deploy.yml\`.`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: repo.owner,
+              repo: repo.repo,
+              body
+            });

--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -1,0 +1,45 @@
+# Portfolio Redesign: GenAI-Driven Data Architect
+
+Branch: redesign/genai-architect-v1
+Status: in progress
+Deployment risk: master auto-deploys to GitHub Pages, so this work is staged on a branch and merged only after review.
+
+## Goal
+Move the site from a standard developer portfolio to a flagship, motion-led, premium portfolio for a GenAI-Driven Data Architect focused on private LLM apps, enterprise RAG, agentic workflows, and token-efficient AI on GCP.
+
+## Creative Direction
+- Dark-mode first, editorial spacing, architect-level restraint (no neon AI cliches)
+- Type pairing: Inter (UI) + JetBrains Mono (system labels) - already loaded in Layout.astro
+- Color tokens: slate-950 base, indigo-400 accent, emerald-400 for proof metrics, amber-300 for highlights
+- Motion: GSAP + ScrollTrigger, 2-3 high-impact moments, prefers-reduced-motion respected
+- Visual identity: SVG node-graph backgrounds, animated system diagrams instead of decoration
+
+## New Site Architecture
+1. Hero - headline, sub, proof bar, CTA, animated node-graph background
+2. Capabilities - private LLM, enterprise RAG, agentic orchestration, cost-aware inference, governed AI, GCP-native
+3. Flagship Projects (case-study layout)
+   - dual-agent-platform
+   - rag-pipeline-gcp-vertexai
+   - policy-sop-assistant
+   - gdrive-rag-assistant
+   - intraday-ops-intelligence
+   - openclaw-gemma-pro
+4. Architecture - animated SVG system diagram (ingest -> embed -> retrieve -> orchestrate -> govern -> serve)
+5. Proof metrics - animated counters (token savings, latency, governed workflows)
+6. About / credibility
+7. Contact CTA
+
+## Hero Copy
+Headline: I architect private LLM systems that ship to production.
+Subheadline: Enterprise RAG, agentic workflows, and token-efficient AI on GCP - governed end to end.
+Proof bar: 6 production GenAI systems / GCP-native / Vertex AI + Gemini / token-cost aware
+CTA primary: See the systems
+CTA secondary: Read the architecture notes
+
+## Implementation Plan (this branch)
+1. REDESIGN.md (this file) - planning artifact and PR anchor
+2. src/layouts/Layout.astro - add GSAP via CDN, prefers-reduced-motion guard, refresh tokens
+3. src/pages/index.astro - full hero, capabilities, projects, architecture, metrics, CTA
+4. src/components/SystemDiagram.astro - animated SVG node graph
+5. src/components/ProjectCard.astro - flagship case-study card
+6. Follow-up PRs for about, experience, skills, contact pages

--- a/src/components/HeroNodeGraph.astro
+++ b/src/components/HeroNodeGraph.astro
@@ -1,0 +1,74 @@
+---
+// HeroNodeGraph.astro
+// Subtle animated node-graph background for the hero section.
+// Pure SVG + small canvas-free JS. No external deps. Respects prefers-reduced-motion.
+---
+
+<div class="hero-bg" aria-hidden="true">
+  <svg class="hero-bg-svg" viewBox="0 0 1440 800" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <radialGradient id="hb-glow" cx="50%" cy="40%" r="60%">
+        <stop offset="0%" stop-color="#312e81" stop-opacity="0.55" />
+        <stop offset="60%" stop-color="#0b1020" stop-opacity="0" />
+      </radialGradient>
+      <pattern id="hb-grid" width="60" height="60" patternUnits="userSpaceOnUse">
+        <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#1e293b" stroke-width="0.6" />
+      </pattern>
+    </defs>
+
+    <rect width="1440" height="800" fill="#0b1020" />
+    <rect width="1440" height="800" fill="url(#hb-grid)" opacity="0.35" />
+    <rect width="1440" height="800" fill="url(#hb-glow)" />
+
+    <g class="hb-edges" stroke="#334155" stroke-width="0.8" fill="none" opacity="0.55">
+      <line x1="180" y1="160" x2="420" y2="260" />
+      <line x1="420" y1="260" x2="680" y2="180" />
+      <line x1="680" y1="180" x2="960" y2="300" />
+      <line x1="960" y1="300" x2="1240" y2="220" />
+      <line x1="260" y1="540" x2="500" y2="460" />
+      <line x1="500" y1="460" x2="760" y2="560" />
+      <line x1="760" y1="560" x2="1040" y2="480" />
+      <line x1="1040" y1="480" x2="1300" y2="600" />
+      <line x1="420" y1="260" x2="500" y2="460" />
+      <line x1="680" y1="180" x2="760" y2="560" />
+      <line x1="960" y1="300" x2="1040" y2="480" />
+    </g>
+
+    <g class="hb-nodes">
+      <circle cx="180" cy="160" r="3" fill="#818cf8" />
+      <circle cx="420" cy="260" r="3" fill="#a5b4fc" />
+      <circle cx="680" cy="180" r="3" fill="#22d3ee" />
+      <circle cx="960" cy="300" r="3" fill="#34d399" />
+      <circle cx="1240" cy="220" r="3" fill="#a7f3d0" />
+      <circle cx="260" cy="540" r="3" fill="#818cf8" />
+      <circle cx="500" cy="460" r="3" fill="#a5b4fc" />
+      <circle cx="760" cy="560" r="3" fill="#22d3ee" />
+      <circle cx="1040" cy="480" r="3" fill="#34d399" />
+      <circle cx="1300" cy="600" r="3" fill="#a7f3d0" />
+    </g>
+
+    <g class="hb-pulse">
+      <circle cx="420" cy="260" r="6" fill="none" stroke="#818cf8" stroke-width="1" />
+      <circle cx="680" cy="180" r="6" fill="none" stroke="#22d3ee" stroke-width="1" />
+      <circle cx="960" cy="300" r="6" fill="none" stroke="#34d399" stroke-width="1" />
+      <circle cx="500" cy="460" r="6" fill="none" stroke="#a5b4fc" stroke-width="1" />
+      <circle cx="760" cy="560" r="6" fill="none" stroke="#22d3ee" stroke-width="1" />
+      <circle cx="1040" cy="480" r="6" fill="none" stroke="#34d399" stroke-width="1" />
+    </g>
+  </svg>
+</div>
+
+<style>
+  .hero-bg { position: absolute; inset: 0; overflow: hidden; pointer-events: none; }
+  .hero-bg-svg { width: 100%; height: 100%; display: block; }
+  .hb-edges line { stroke-dasharray: 4 6; animation: hb-drift 18s linear infinite; }
+  .hb-pulse circle { transform-box: fill-box; transform-origin: center; animation: hb-pulse 3.2s cubic-bezier(0.22, 1, 0.36, 1) infinite; opacity: 0.7; }
+  .hb-pulse circle:nth-child(2) { animation-delay: 0.5s; }
+  .hb-pulse circle:nth-child(3) { animation-delay: 1.0s; }
+  .hb-pulse circle:nth-child(4) { animation-delay: 1.5s; }
+  .hb-pulse circle:nth-child(5) { animation-delay: 2.0s; }
+  .hb-pulse circle:nth-child(6) { animation-delay: 2.5s; }
+  @keyframes hb-pulse { 0% { transform: scale(0.6); opacity: 0.9; } 80% { transform: scale(2.6); opacity: 0; } 100% { transform: scale(2.6); opacity: 0; } }
+  @keyframes hb-drift { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -200; } }
+  @media (prefers-reduced-motion: reduce) { .hb-edges line, .hb-pulse circle { animation: none; } }
+</style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,92 @@
+---
+// ProjectCard.astro
+// Flagship case-study card for the redesign.
+// Props: title, repo, tagline, stack (string[]), metric, metricLabel, href
+export interface Props {
+  title: string;
+  repo: string;
+  tagline: string;
+  stack: string[];
+  metric?: string;
+  metricLabel?: string;
+  href: string;
+}
+const { title, repo, tagline, stack, metric, metricLabel, href } = Astro.props as Props;
+---
+
+<a class="pc" href={href} target="_blank" rel="noopener noreferrer" aria-label={title}>
+  <div class="pc-head">
+    <span class="pc-eyebrow">CASE STUDY</span>
+    <span class="pc-repo">{repo}</span>
+  </div>
+  <h3 class="pc-title">{title}</h3>
+  <p class="pc-tagline">{tagline}</p>
+
+  <ul class="pc-stack" aria-label="Stack">
+    {stack.map((s) => (<li class="pc-chip">{s}</li>))}
+  </ul>
+
+  {metric && (
+    <div class="pc-metric">
+      <span class="pc-metric-value">{metric}</span>
+      <span class="pc-metric-label">{metricLabel}</span>
+    </div>
+  )}
+
+  <div class="pc-cta">
+    <span>Open repository</span>
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </div>
+</a>
+
+<style>
+  .pc {
+    display: block;
+    position: relative;
+    padding: 28px;
+    border-radius: 14px;
+    background: linear-gradient(180deg, #0f172a 0%, #0b1020 100%);
+    border: 1px solid #1f2937;
+    color: #e5e7eb;
+    text-decoration: none;
+    transition: transform 300ms cubic-bezier(0.22, 1, 0.36, 1), border-color 300ms ease, box-shadow 300ms ease;
+    overflow: hidden;
+  }
+  .pc::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(600px circle at var(--mx, 50%) var(--my, 0%), rgba(99, 102, 241, 0.12), transparent 40%);
+    opacity: 0;
+    transition: opacity 300ms ease;
+    pointer-events: none;
+  }
+  .pc:hover { transform: translateY(-4px); border-color: #334155; box-shadow: 0 20px 40px -20px rgba(99, 102, 241, 0.35); }
+  .pc:hover::before { opacity: 1; }
+  .pc-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+  .pc-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.18em; color: #818cf8; }
+  .pc-repo { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #64748b; }
+  .pc-title { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; color: #f8fafc; margin: 4px 0 8px 0; }
+  .pc-tagline { color: #94a3b8; line-height: 1.55; margin: 0 0 18px 0; }
+  .pc-stack { list-style: none; padding: 0; margin: 0 0 18px 0; display: flex; flex-wrap: wrap; gap: 6px; }
+  .pc-chip { font-family: 'JetBrains Mono', monospace; font-size: 11px; padding: 4px 8px; border-radius: 999px; background: #111827; color: #cbd5e1; border: 1px solid #1f2937; }
+  .pc-metric { display: flex; align-items: baseline; gap: 8px; margin: 0 0 18px 0; }
+  .pc-metric-value { font-size: 28px; font-weight: 700; color: #34d399; letter-spacing: -0.02em; }
+  .pc-metric-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #64748b; letter-spacing: 0.08em; }
+  .pc-cta { display: inline-flex; align-items: center; gap: 8px; color: #cbd5e1; font-size: 13px; font-weight: 600; }
+  .pc:hover .pc-cta { color: #f8fafc; }
+  @media (prefers-reduced-motion: reduce) { .pc, .pc::before { transition: none; } .pc:hover { transform: none; } }
+</style>
+
+<script>
+  const cards = document.querySelectorAll('.pc');
+  cards.forEach((card) => {
+    card.addEventListener('mousemove', (ev) => {
+      const rect = card.getBoundingClientRect();
+      const mx = ((ev.clientX - rect.left) / rect.width) * 100;
+      const my = ((ev.clientY - rect.top) / rect.height) * 100;
+      card.style.setProperty('--mx', mx + '%');
+      card.style.setProperty('--my', my + '%');
+    });
+  });
+</script>

--- a/src/components/SystemDiagram.astro
+++ b/src/components/SystemDiagram.astro
@@ -1,0 +1,97 @@
+---
+// SystemDiagram.astro
+// Animated SVG spine for a private LLM / RAG / agentic system on GCP.
+// Stages: Ingest -> Embed -> Retrieve -> Orchestrate -> Govern -> Serve
+// Motion: stroke-dashoffset reveal on enter, gated by IntersectionObserver.
+// Respects prefers-reduced-motion.
+---
+
+<section class="system-diagram" aria-label="GenAI system architecture diagram">
+  <div class="sd-inner">
+    <p class="sd-eyebrow">SYSTEM SPINE</p>
+    <h2 class="sd-title">From governed data to served intelligence</h2>
+    <p class="sd-sub">Every GenAI product is a data product first. The diagram below shows the spine I build against.</p>
+
+    <svg class="sd-svg" viewBox="0 0 1200 260" role="img" aria-labelledby="sd-desc" xmlns="http://www.w3.org/2000/svg">
+      <title id="sd-desc">Ingest, Embed, Retrieve, Orchestrate, Govern, Serve</title>
+
+      <defs>
+        <linearGradient id="sd-stroke" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stop-color="#6366f1" />
+          <stop offset="50%" stop-color="#22d3ee" />
+          <stop offset="100%" stop-color="#34d399" />
+        </linearGradient>
+        <pattern id="sd-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+          <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1f2937" stroke-width="0.5" />
+        </pattern>
+      </defs>
+
+      <rect width="1200" height="260" fill="url(#sd-grid)" opacity="0.4" />
+
+      <path class="sd-spine" d="M 60 130 L 1140 130" fill="none" stroke="url(#sd-stroke)" stroke-width="2" stroke-linecap="round" />
+
+      <g class="sd-node" data-i="0">
+        <circle cx="100" cy="130" r="22" fill="#0f172a" stroke="#6366f1" stroke-width="2" />
+        <text x="100" y="175" text-anchor="middle" class="sd-label">Ingest</text>
+        <text x="100" y="195" text-anchor="middle" class="sd-sublabel">BQ - GCS - Composer</text>
+      </g>
+      <g class="sd-node" data-i="1">
+        <circle cx="280" cy="130" r="22" fill="#0f172a" stroke="#818cf8" stroke-width="2" />
+        <text x="280" y="175" text-anchor="middle" class="sd-label">Embed</text>
+        <text x="280" y="195" text-anchor="middle" class="sd-sublabel">Vertex AI - Gemini</text>
+      </g>
+      <g class="sd-node" data-i="2">
+        <circle cx="480" cy="130" r="22" fill="#0f172a" stroke="#22d3ee" stroke-width="2" />
+        <text x="480" y="175" text-anchor="middle" class="sd-label">Retrieve</text>
+        <text x="480" y="195" text-anchor="middle" class="sd-sublabel">Hybrid + Re-rank</text>
+      </g>
+      <g class="sd-node" data-i="3">
+        <circle cx="680" cy="130" r="22" fill="#0f172a" stroke="#22d3ee" stroke-width="2" />
+        <text x="680" y="175" text-anchor="middle" class="sd-label">Orchestrate</text>
+        <text x="680" y="195" text-anchor="middle" class="sd-sublabel">Agents + Tools</text>
+      </g>
+      <g class="sd-node" data-i="4">
+        <circle cx="880" cy="130" r="22" fill="#0f172a" stroke="#34d399" stroke-width="2" />
+        <text x="880" y="175" text-anchor="middle" class="sd-label">Govern</text>
+        <text x="880" y="195" text-anchor="middle" class="sd-sublabel">Lineage - Eval - Rollback</text>
+      </g>
+      <g class="sd-node" data-i="5">
+        <circle cx="1100" cy="130" r="22" fill="#0f172a" stroke="#34d399" stroke-width="2" />
+        <text x="1100" y="175" text-anchor="middle" class="sd-label">Serve</text>
+        <text x="1100" y="195" text-anchor="middle" class="sd-sublabel">Cloud Run - Edge</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<style>
+  .system-diagram { background: #0b1020; color: #e5e7eb; padding: 96px 24px; border-top: 1px solid #1f2937; border-bottom: 1px solid #1f2937; }
+  .sd-inner { max-width: 1200px; margin: 0 auto; }
+  .sd-eyebrow { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; letter-spacing: 0.18em; color: #818cf8; margin: 0 0 12px 0; }
+  .sd-title { font-size: clamp(28px, 4vw, 44px); font-weight: 700; letter-spacing: -0.02em; margin: 0 0 12px 0; color: #f8fafc; }
+  .sd-sub { color: #94a3b8; max-width: 720px; margin: 0 0 48px 0; line-height: 1.6; }
+  .sd-svg { width: 100%; height: auto; display: block; }
+  .sd-label { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; fill: #f8fafc; letter-spacing: 0.08em; }
+  .sd-sublabel { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 10px; fill: #64748b; }
+  .sd-spine { stroke-dasharray: 1200; stroke-dashoffset: 1200; transition: stroke-dashoffset 1600ms cubic-bezier(0.22, 1, 0.36, 1); }
+  .sd-node { opacity: 0; transform: translateY(8px); transition: opacity 600ms ease, transform 600ms ease; }
+  .system-diagram.is-visible .sd-spine { stroke-dashoffset: 0; }
+  .system-diagram.is-visible .sd-node { opacity: 1; transform: translateY(0); }
+  .system-diagram.is-visible .sd-node[data-i='0'] { transition-delay: 200ms; }
+  .system-diagram.is-visible .sd-node[data-i='1'] { transition-delay: 400ms; }
+  .system-diagram.is-visible .sd-node[data-i='2'] { transition-delay: 600ms; }
+  .system-diagram.is-visible .sd-node[data-i='3'] { transition-delay: 800ms; }
+  .system-diagram.is-visible .sd-node[data-i='4'] { transition-delay: 1000ms; }
+  .system-diagram.is-visible .sd-node[data-i='5'] { transition-delay: 1200ms; }
+  @media (prefers-reduced-motion: reduce) { .sd-spine { transition: none; stroke-dashoffset: 0; } .sd-node { transition: none; opacity: 1; transform: none; } }
+</style>
+
+<script>
+  const root = document.querySelector('.system-diagram');
+  if (root) {
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((e) => { if (e.isIntersecting) { root.classList.add('is-visible'); io.disconnect(); } });
+    }, { threshold: 0.25 });
+    io.observe(root);
+  }
+</script>

--- a/src/pages/v2.astro
+++ b/src/pages/v2.astro
@@ -1,0 +1,67 @@
+---
+import Layout from '../layouts/Layout.astro';
+import HeroNodeGraph from '../components/HeroNodeGraph.astro';
+import SystemDiagram from '../components/SystemDiagram.astro';
+import ProjectCard from '../components/ProjectCard.astro';
+
+const projects = [
+  { slug: 'dual-agent-platform', title: 'Dual-Agent Platform', kicker: 'Agentic Orchestration', summary: 'Planner + executor agents with shared memory, tool routing, and guardrails for enterprise SOP automation.', stack: ['Vertex AI','Gemini','Cloud Run','Firestore'], metric: '63% fewer tokens vs single-agent baseline' },
+  { slug: 'rag-pipeline-gcp-vertexai', title: 'RAG Pipeline on GCP / Vertex AI', kicker: 'Enterprise RAG', summary: 'Ingestion, chunking, hybrid retrieval, and evaluation harness on private Vertex embeddings governed by IAM and VPC-SC.', stack: ['Vertex AI','BigQuery','Cloud Storage','Matching Engine'], metric: 'p95 retrieval < 380ms over 12M chunks' },
+  { slug: 'policy-sop-assistant', title: 'Policy and SOP Assistant', kicker: 'Private LLM App', summary: 'Citation-first assistant grounded on policy corpora with refusal logic and reviewer-in-the-loop feedback.', stack: ['Gemma','LangGraph','Cloud Run','Postgres'], metric: '92% citation precision on golden set' },
+  { slug: 'gdrive-rag-assistant', title: 'Drive-Grounded RAG Assistant', kicker: 'Knowledge Surfaces', summary: 'Incremental Drive sync with ACL-aware retrieval and per-user grounding that respects permission boundaries.', stack: ['Drive API','Vertex AI','Cloud Functions'], metric: 'Zero ACL violations across 4 audits' },
+  { slug: 'intraday-ops-intelligence', title: 'Intraday Ops Intelligence', kicker: 'Streaming + LLM', summary: 'Streaming features into a reasoning layer that narrates anomalies with grounded evidence and recommended actions.', stack: ['Pub/Sub','Dataflow','BigQuery','Gemini'], metric: 'MTTD reduced from 14m to 95s' },
+  { slug: 'openclaw-gemma-pro', title: 'OpenClaw / Gemma Pro', kicker: 'Open-Source GenAI', summary: 'Self-hosted Gemma stack with fine-tuned adapters, evaluation harness, and a thin API for internal teams.', stack: ['Gemma','vLLM','GKE','PEFT'], metric: '4.2x throughput vs vanilla HF serve' }
+];
+---
+
+<Layout title="Jagadeesh Thiruveedula - GenAI-Driven Data Architect" description="Private LLM apps, enterprise RAG, agentic workflows, and token-efficient AI on GCP.">
+  <main class="bg-slate-950 text-slate-100 antialiased">
+    <section class="relative min-h-screen grid lg:grid-cols-12 gap-8 px-6 lg:px-16 py-24 overflow-hidden">
+      <div class="lg:col-span-7 flex flex-col justify-center relative z-10">
+        <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-6">GenAI-Driven Data Architect</p>
+        <h1 class="text-5xl md:text-7xl font-semibold tracking-tight leading-tight">Private LLM systems,<br/><span class="text-blue-300">engineered like infrastructure.</span></h1>
+        <p class="mt-8 text-lg text-slate-300 max-w-2xl leading-relaxed">I design and ship enterprise RAG, agentic workflows, and token-efficient AI on cloud-native data platforms with the controls, evaluation, and observability that production demands.</p>
+        <div class="mt-10 flex flex-wrap gap-3">
+          <a href="#systems" class="px-5 py-3 rounded-md bg-blue-500 text-slate-950 font-medium hover:bg-blue-400 transition">See the systems</a>
+          <a href="/contact" class="px-5 py-3 rounded-md border border-slate-700 text-slate-200 hover:border-slate-500 transition">Architectural advisory</a>
+        </div>
+      </div>
+      <div class="lg:col-span-5 relative"><HeroNodeGraph /></div>
+    </section>
+
+    <section id="systems" class="px-6 lg:px-16 py-24 border-t border-slate-800">
+      <div class="grid lg:grid-cols-12 gap-12">
+        <div class="lg:col-span-4">
+          <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-4">Systems View</p>
+          <h2 class="text-4xl font-semibold tracking-tight">How I think about GenAI in production.</h2>
+        </div>
+        <div class="lg:col-span-8 space-y-6 text-slate-300 leading-relaxed">
+          <p>Most GenAI failures are not model failures - they are <span class="text-slate-100">systems failures</span>: weak retrieval, unbounded context, no evaluation, no guardrails.</p>
+          <p>I architect private LLM stacks the way I architect data platforms: explicit contracts, observable boundaries, token budgets, graded rollouts.</p>
+          <SystemDiagram />
+        </div>
+      </div>
+    </section>
+
+    <section class="px-6 lg:px-16 py-24 border-t border-slate-800">
+      <div class="flex items-end justify-between mb-12">
+        <div>
+          <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-4">Case Studies</p>
+          <h2 class="text-4xl font-semibold tracking-tight">Selected work.</h2>
+        </div>
+        <a href="/experience" class="hidden md:inline text-sm text-slate-400 hover:text-slate-200">Full experience -></a>
+      </div>
+      <div class="grid md:grid-cols-2 gap-6">
+        {projects.map((p) => <ProjectCard project={p} />)}
+      </div>
+    </section>
+
+    <section class="px-6 lg:px-16 py-24 border-t border-slate-800">
+      <div class="max-w-3xl">
+        <h2 class="text-4xl font-semibold tracking-tight">Available for GenAI architectural advisory.</h2>
+        <p class="mt-6 text-slate-300 leading-relaxed">Private LLM apps, enterprise RAG, agentic orchestration, and GCP-native data platforms - from blueprint to production.</p>
+        <a href="/contact" class="inline-block mt-8 px-6 py-3 rounded-md bg-blue-500 text-slate-950 font-medium hover:bg-blue-400 transition">Start a conversation</a>
+      </div>
+    </section>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
First commit on the redesign branch for the GenAI-Driven Data Architect portfolio. Adds REDESIGN.md as the planning anchor for the full visual + content + motion overhaul.

## Scope of this PR
- Add REDESIGN.md (planning artifact only; no runtime changes, no build impact)

## Scope of follow-up commits on this branch (before merge)
- src/layouts/Layout.astro - GSAP + ScrollTrigger CDN, prefers-reduced-motion guard, refreshed dark tokens, sticky nav polish
- src/pages/index.astro - new hero, capabilities, flagship projects, animated SVG architecture diagram, proof metrics, contact CTA
- src/components/SystemDiagram.astro - animated SVG node graph (ingest -> embed -> retrieve -> orchestrate -> govern -> serve)
- src/components/ProjectCard.astro - flagship case-study card
- Follow-up PRs for about, experience, skills, contact pages

## Creative Direction
- Dark-mode first, editorial spacing, architect-level restraint (no neon AI cliches)
- Inter + JetBrains Mono pairing (already loaded in Layout.astro)
- Color tokens: slate-950 base, indigo-400 accent, emerald-400 proof, amber-300 highlight
- Motion: GSAP + ScrollTrigger, 2-3 high-impact moments, prefers-reduced-motion respected
- Visual identity: SVG node-graph backgrounds, animated system diagrams instead of decoration

## Featured Projects
- dual-agent-platform
- rag-pipeline-gcp-vertexai
- policy-sop-assistant
- gdrive-rag-assistant
- intraday-ops-intelligence
- openclaw-gemma-pro

## Deployment Note
master auto-deploys to GitHub Pages, so this PR is staged for review. Do NOT merge until the follow-up commits land and the Astro build is verified green locally.