### PR TITLE
polish: hero dedup, skills dashboard depth, experience timeline, typo…

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,81 +63,10 @@ import Layout from '../layouts/Layout.astro';
     <section class="max-w-3xl text-center" aria-labelledby="cta-heading">
       <div class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)] md:p-10">
         <h2 id="cta-heading" class="text-2xl font-black text-white md:text-3xl">Ready to Transform Your Data Strategy?</h2>
-        <p class="mt-4 text-sm text-slate-400 leading-relaxed">Let’s discuss how cloud modernization and GenAI can drive measurable business impact for your organization.</p>
+        <p class="mt-4 text-sm text-slate-400 leading-relaxed">Let's discuss how cloud modernization and GenAI can drive measurable business impact for your organization.</p>
         <div class="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
           <a href="/contact" class="inline-flex items-center justify-center rounded-full bg-cyan-400 px-7 py-3 text-sm font-bold text-slate-950 transition-all duration-200 hover:bg-cyan-300">Get In Touch</a>
           <a href="/experience" class="inline-flex items-center justify-center rounded-full border border-slate-700 bg-slate-900/60 px-7 py-3 text-sm font-semibold text-slate-300 transition-all duration-200 hover:border-cyan-400/40 hover:text-cyan-100">View Experience</a>
-        </div>
-      </div>
-    </section>
-    <section class="grid grid-cols-1 md:grid-cols-3 w-full max-w-5xl gap-6 lg:gap-8 mb-12" aria-labelledby="expertise-heading">
-      <h2 id="expertise-heading" class="sr-only">Areas of Technical Expertise</h2>
-      
-      <article class="card flex flex-col items-center p-6 lg:p-8 gap-4 text-center hover:shadow-xl transition-shadow duration-300 border border-gray-200 dark:border-gray-700">
-        <div class="bg-blue-100 dark:bg-blue-800/30 p-4 rounded-full">
-          <svg class="w-12 h-12 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 20l9-7l-9-7l-9 7l9 7z" stroke-width="2"></path>
-            <path d="M12 4v16" stroke-width="2"></path>
-          </svg>
-        </div>
-        <h3 class="text-base font-bold text-white">Cloud Data Architectures</h3>
-        <p class="text-sm text-slate-400 leading-relaxed">
-          Expert in GCP, BigQuery, Dataflow & multi-cloud datalake platforms. Leading $MM data transformations with enterprise-grade security and scalability.
-        </p>
-      </article>
-      
-      <article class="card flex flex-col items-center p-6 lg:p-8 gap-4 text-center hover:shadow-xl transition-shadow duration-300 border border-gray-200 dark:border-gray-700">
-        <div class="bg-green-100 dark:bg-green-800/30 p-4 rounded-full">
-          <svg class="w-12 h-12 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke-width="2"></circle>
-            <path d="M8 12h8m-4-4v8" stroke-width="2"></path>
-          </svg>
-        </div>
-        <h3 class="text-base font-bold text-white">Enterprise GenAI & Vector Search</h3>
-        <p class="text-sm text-slate-400 leading-relaxed">
-          Building GenAI at scale: Vertex AI, secure LLMs, RAG, Pinecone, Weaviate—driving measurable business value and competitive advantage.
-        </p>
-      </article>
-      
-      <article class="card flex flex-col items-center p-6 lg:p-8 gap-4 text-center hover:shadow-xl transition-shadow duration-300 border border-gray-200 dark:border-gray-700">
-        <div class="bg-indigo-100 dark:bg-indigo-800/30 p-4 rounded-full">
-          <svg class="w-12 h-12 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M3 10h18M4 6h16M6 18h12" stroke-width="2"></path>
-          </svg>
-        </div>
-        <h3 class="text-base font-bold text-white">Impact & Leadership</h3>
-        <p class="text-sm text-slate-400 leading-relaxed">
-          Trusted for cloud adoption, cost optimization, and high-SLA delivery at Quantiphi, Charles Schwab, and Fortune 500 enterprises.
-        </p>
-      </article>
-    </section>
-
-    <!-- Section Divider -->
-    <div class="w-full max-w-4xl my-12">
-      <hr class="border-t-2 border-gray-200 dark:border-gray-700 rounded-full" />
-      <div class="flex justify-center -mt-3">
-        <span class="bg-white dark:bg-gray-900 px-6 py-2 text-gray-500 dark:text-gray-400 text-sm font-medium">Let's Connect</span>
-      </div>
-    </div>
-
-    <!-- CTA Section -->
-    <section class="max-w-3xl w-full text-center" aria-labelledby="cta-heading">
-      <div class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)] md:p-10">
-        <h2 id="cta-heading" class="text-2xl font-black text-white md:text-3xl">Ready to Transform Your Data Strategy?</h2>
-        <p class="mt-4 text-sm text-slate-400 leading-relaxed">
-          Let's discuss how cloud modernization and GenAI can drive measurable business impact for your organization.
-        </p>
-        <div class="flex flex-col sm:flex-row gap-4 justify-center">
-          <a href="/contact" 
-             class="inline-flex items-center justify-center rounded-full bg-cyan-400 px-7 py-3 text-sm font-bold text-slate-950 transition-all duration-200 hover:bg-cyan-300"
-             aria-label="Navigate to contact page">
-            Get In Touch
-          </a>
-          <a href="/projects" 
-             class="inline-flex items-center justify-center rounded-full border border-slate-700 bg-slate-900/60 px-7 py-3 text-sm font-semibold text-slate-300 transition-all duration-200 hover:border-cyan-400/40 hover:text-cyan-100"
-             aria-label="View my portfolio projects">
-            View Projects
-          </a>
         </div>
       </div>
     </section>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -13,47 +13,103 @@ import Layout from '../layouts/Layout.astro';
 
       <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 md:p-8">
         <p class="section-eyebrow text-indigo-300">[MODULE: WORK]</p>
-        <div class="mt-6 space-y-6 border-l border-slate-800/70 pl-6">
-          {[
-            ['Data Architect','Quantiphi','Sep 2022 – Present','GCP modernization, RAG platforms, evaluation harnesses, and secure enterprise AI delivery.','GCP · GenAI · RAG · IAM'],
-            ['Senior Data Engineer','Charles Schwab','Nov 2021 – Sep 2022','Migrated warehouse workloads to GCP and stabilized CI/CD, observability, and performance at scale.','BigQuery · PySpark · Terraform · DevOps'],
-            ['Data Engineer','Wiley Publications','Mar 2019 – Nov 2021','Built ETL pipelines, data integration layers, and analytics workflows for publishing platforms.','ETL · Data Pipelines · Analytics'],
-          ].map(([role, company, date, summary, chips]) => (
-            <article class="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-              <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                <div>
-                  <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
-                  <p class="text-sm text-slate-400">{company}</p>
+        <div class="mt-6">
+          <div class="hidden md:flex relative">
+            <!-- Vertical timeline line -->
+            <div class="absolute left-3 top-0 bottom-0 w-px bg-slate-600/30" aria-hidden="true"></div>
+            <div class="pl-10 space-y-6">
+              {[
+                ['Data Architect','Quantiphi','Sep 2022 – Present','GCP modernization, RAG platforms, evaluation harnesses, and secure enterprise AI delivery.','GCP · GenAI · RAG · IAM'],
+                ['Senior Data Engineer','Charles Schwab','Nov 2021 – Sep 2022','Migrated warehouse workloads to GCP and stabilized CI/CD, observability, and performance at scale.','BigQuery · PySpark · Terraform · DevOps'],
+                ['Data Engineer','Wiley Publications','Mar 2019 – Nov 2021','Built ETL pipelines, data integration layers, and analytics workflows for publishing platforms.','ETL · Data Pipelines · Analytics'],
+              ].map(([role, company, date, summary, chips], index) => (
+                <article class="relative rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)] timeline-card">
+                  <!-- Timeline dot -->
+                  <div class="absolute -left-10 top-6 w-2 h-2 rounded-full bg-indigo-400/70 ring-4 ring-slate-950" aria-hidden="true"></div>
+                  <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
+                      <p class="text-sm text-slate-400">{company}</p>
+                    </div>
+                    <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
+                  </div>
+                  <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
+                  <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
+                </article>
+              ))}
+            </div>
+          </div>
+          <!-- Mobile fallback: stacked cards without line -->
+          <div class="md:hidden space-y-6 border-l border-slate-800/70 pl-6">
+            {[
+              ['Data Architect','Quantiphi','Sep 2022 – Present','GCP modernization, RAG platforms, evaluation harnesses, and secure enterprise AI delivery.','GCP · GenAI · RAG · IAM'],
+              ['Senior Data Engineer','Charles Schwab','Nov 2021 – Sep 2022','Migrated warehouse workloads to GCP and stabilized CI/CD, observability, and performance at scale.','BigQuery · PySpark · Terraform · DevOps'],
+              ['Data Engineer','Wiley Publications','Mar 2019 – Nov 2021','Built ETL pipelines, data integration layers, and analytics workflows for publishing platforms.','ETL · Data Pipelines · Analytics'],
+            ].map(([role, company, date, summary, chips]) => (
+              <article class="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+                <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
+                    <p class="text-sm text-slate-400">{company}</p>
+                  </div>
+                  <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
                 </div>
-                <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
-              </div>
-              <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
-              <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
-            </article>
-          ))}
+                <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
+                <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
 
       <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 md:p-8">
         <p class="section-eyebrow text-cyan-300">[MODULE: EARLY CAREER]</p>
-        <div class="mt-6 space-y-6 border-l border-slate-800/70 pl-6">
-          {[
-            ['Software Engineer','DSOgroup TEOTYS','Aug 2018 – Mar 2019','Talend streaming jobs, CDC pipelines, and DR-ready data frameworks.','Talend · ETL · CDC'],
-            ['Software Engineer','Innominds','Jun 2015 – Jul 2018','Warehouse and ETL design with reusable business logic and reliability improvements.','ETL · Talend · Data Quality'],
-            ['Intern','Vizag Steel Plant','Jan 2015 – Mar 2015','SCADA and automation work for monitoring and operational troubleshooting.','IoT · Automation · Monitoring'],
-          ].map(([role, company, date, summary, chips]) => (
-            <article class="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-              <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                <div>
-                  <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
-                  <p class="text-sm text-slate-400">{company}</p>
+        <div class="mt-6">
+          <div class="hidden md:flex relative">
+            <!-- Vertical timeline line -->
+            <div class="absolute left-3 top-0 bottom-0 w-px bg-slate-600/30" aria-hidden="true"></div>
+            <div class="pl-10 space-y-6">
+              {[
+                ['Software Engineer','DSOgroup TEOTYS','Aug 2018 – Mar 2019','Talend streaming jobs, CDC pipelines, and DR-ready data frameworks.','Talend · ETL · CDC'],
+                ['Software Engineer','Innominds','Jun 2015 – Jul 2018','Warehouse and ETL design with reusable business logic and reliability improvements.','ETL · Talend · Data Quality'],
+                ['Intern','Vizag Steel Plant','Jan 2015 – Mar 2015','SCADA and automation work for monitoring and operational troubleshooting.','IoT · Automation · Monitoring'],
+              ].map(([role, company, date, summary, chips]) => (
+                <article class="relative rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)] timeline-card">
+                  <!-- Timeline dot -->
+                  <div class="absolute -left-10 top-6 w-2 h-2 rounded-full bg-indigo-400/70 ring-4 ring-slate-950" aria-hidden="true"></div>
+                  <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
+                      <p class="text-sm text-slate-400">{company}</p>
+                    </div>
+                    <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
+                  </div>
+                  <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
+                  <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
+                </article>
+              ))}
+            </div>
+          </div>
+          <!-- Mobile fallback: stacked cards without line -->
+          <div class="md:hidden space-y-6 border-l border-slate-800/70 pl-6">
+            {[
+              ['Software Engineer','DSOgroup TEOTYS','Aug 2018 – Mar 2019','Talend streaming jobs, CDC pipelines, and DR-ready data frameworks.','Talend · ETL · CDC'],
+              ['Software Engineer','Innominds','Jun 2015 – Jul 2018','Warehouse and ETL design with reusable business logic and reliability improvements.','ETL · Talend · Data Quality'],
+              ['Intern','Vizag Steel Plant','Jan 2015 – Mar 2015','SCADA and automation work for monitoring and operational troubleshooting.','IoT · Automation · Monitoring'],
+            ].map(([role, company, date, summary, chips]) => (
+              <article class="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+                <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h2 class="text-base font-bold text-white md:text-lg">{role}</h2>
+                    <p class="text-sm text-slate-400">{company}</p>
+                  </div>
+                  <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
                 </div>
-                <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{date}</span>
-              </div>
-              <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
-              <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
-            </article>
-          ))}
+                <p class="mt-4 text-sm text-slate-400 leading-relaxed">{summary}</p>
+                <div class="mt-4 flex flex-wrap gap-2">{chips.split(' · ').map(tag => <span class="rounded border border-slate-700/60 bg-slate-900/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}</div>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,10 +121,7 @@ const capabilityCards = [
           <span id="hero-status-text">// SYSTEM_STATE: ACTIVE</span>
         </div>
 
-        <!-- Subtitle -->
-        <p class="hero-subtitle text-[11px] font-mono font-semibold uppercase tracking-[0.3em] text-slate-400">Command surface for production AI</p>
-
-        <!-- H1 — split into lines for stagger reveal -->
+        <!-- H1 — split into chars for stagger reveal -->
         <h1 id="hero-headline" class="hero-title font-black tracking-tight text-white leading-[1.05]" style="font-size: clamp(3rem, 0.5rem + 7vw, 8rem);">
           COMMAND SURFACE FOR PRODUCTION AI
         </h1>
@@ -506,9 +503,7 @@ const capabilityCards = [
     .scroll-line {
       animation: none;
     }
-    .hero-line,
     .hero-badge,
-    .hero-subtitle,
     .hero-description,
     .hero-tags,
     .hero-ctas {
@@ -586,15 +581,12 @@ const capabilityCards = [
     const tlHero = gsap.timeline({ defaults: { ease: 'power3.out' } });
 
     // Set initial states
-    gsap.set('.hero-line',        { y: '105%' });
-    gsap.set(['.hero-badge', '.hero-subtitle', '.hero-description', '.hero-ctas'], { y: 18, opacity: 0 });
+    gsap.set(['.hero-badge', '.hero-description', '.hero-ctas'], { y: 18, opacity: 0 });
     gsap.set('.hero-tags',        { y: 10, opacity: 0 });
     gsap.set('.scroll-indicator', { opacity: 0 });
 
     tlHero
       .to('.hero-badge',       { y: 0, opacity: 1, duration: 0.7, delay: 0.15 })
-      .to('.hero-subtitle',    { y: 0, opacity: 1, duration: 0.6 }, '-=0.45')
-      .to('.hero-line',        { y: '0%', duration: 0.85, stagger: 0.1 }, '-=0.35')
       .to('.hero-description', { y: 0, opacity: 1, duration: 0.7 }, '-=0.45')
       .to('.hero-tags',        { y: 0, opacity: 1, duration: 0.5 }, '-=0.5')
       .to('.hero-ctas',        { y: 0, opacity: 1, duration: 0.5 }, '-=0.4')

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -14,11 +14,12 @@ import Layout from '../layouts/Layout.astro';
       <section class="grid gap-6 md:grid-cols-2">
         <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
           <h2 class="text-sm font-bold text-white">Platform & Cloud</h2>
-          <div class="mt-5 space-y-4">
+          <p class="mt-1 text-xs text-slate-500 max-w-xs">Where the systems actually run.</p>
+          <div class="mt-5 space-y-5">
             {['GCP', 'BigQuery', 'Dataflow', 'Vertex AI', 'Cloud Run', 'Terraform'].map((item, i) => (
-              <div>
+              <div class="skill-bar" data-percent={[95, 88, 82, 78, 74, 70][i]}>
                 <div class="mb-1 flex items-center justify-between text-[11px] font-mono text-slate-400"><span>{item}</span><span>{[95, 88, 82, 78, 74, 70][i]}%</span></div>
-                <div class="h-1.5 rounded-full bg-slate-800/80"><div class="h-1.5 rounded-full bg-gradient-to-r from-cyan-400 via-indigo-400 to-emerald-400" style={`width:${[95, 88, 82, 78, 74, 70][i]}%`}></div></div>
+                <div class="h-px rounded-none bg-slate-800/80 overflow-hidden"><div class="h-px rounded-none bg-gradient-to-r from-cyan-400 via-indigo-400 to-emerald-400 transform origin-left scale-x-0" style={`--target-width: ${[95, 88, 82, 78, 74, 70][i]}%;`}></div></div>
               </div>
             ))}
           </div>
@@ -26,11 +27,12 @@ import Layout from '../layouts/Layout.astro';
 
         <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
           <h2 class="text-sm font-bold text-white">AI & Retrieval</h2>
-          <div class="mt-5 space-y-4">
+          <p class="mt-1 text-xs text-slate-500 max-w-xs">How models see and navigate your data.</p>
+          <div class="mt-5 space-y-5">
             {['RAG', 'LLM Ops', 'Vector Search', 'Eval Harness', 'Guardrails', 'Observability'].map((item, i) => (
-              <div>
+              <div class="skill-bar" data-percent={[92, 89, 86, 81, 77, 74][i]}>
                 <div class="mb-1 flex items-center justify-between text-[11px] font-mono text-slate-400"><span>{item}</span><span>{[92, 89, 86, 81, 77, 74][i]}%</span></div>
-                <div class="h-1.5 rounded-full bg-slate-800/80"><div class="h-1.5 rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-indigo-400" style={`width:${[92, 89, 86, 81, 77, 74][i]}%`}></div></div>
+                <div class="h-px rounded-none bg-slate-800/80 overflow-hidden"><div class="h-px rounded-none bg-gradient-to-r from-emerald-400 via-cyan-400 to-indigo-400 transform origin-left scale-x-0" style={`--target-width: ${[92, 89, 86, 81, 77, 74][i]}%;`}></div></div>
               </div>
             ))}
           </div>
@@ -66,3 +68,42 @@ import Layout from '../layouts/Layout.astro';
     </section>
   </main>
 </Layout>
+
+<script>
+  import gsap from 'gsap';
+  import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (!prefersReduced) {
+    document.querySelectorAll('.skill-bar').forEach((bar) => {
+      const inner = bar.querySelector('div:last-child > div') as HTMLElement;
+      const targetWidth = bar.getAttribute('data-percent');
+      if (inner && targetWidth) {
+        ScrollTrigger.create({
+          trigger: bar,
+          start: 'top 85%',
+          once: true,
+          onEnter: () => {
+            gsap.to(inner, {
+              scaleX: parseInt(targetWidth) / 100,
+              duration: 1.2,
+              ease: 'power3.out',
+            });
+          },
+        });
+      }
+    });
+  } else {
+    // Respect reduced motion - show bars at full width immediately
+    document.querySelectorAll('.skill-bar').forEach((bar) => {
+      const inner = bar.querySelector('div:last-child > div') as HTMLElement;
+      const targetWidth = bar.getAttribute('data-percent');
+      if (inner && targetWidth) {
+        inner.style.transform = `scaleX(${parseInt(targetWidth) / 100})`;
+      }
+    });
+  }
+</script>

--- a/src/pages/v2.astro
+++ b/src/pages/v2.astro
@@ -18,12 +18,12 @@ const projects = [
   <main class="bg-slate-950 text-slate-100 antialiased">
     <section class="relative min-h-screen grid lg:grid-cols-12 gap-8 px-6 lg:px-16 py-24 overflow-hidden">
       <div class="lg:col-span-7 flex flex-col justify-center relative z-10">
-        <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-6">GenAI-Driven Data Architect</p>
-        <h1 class="text-5xl md:text-7xl font-semibold tracking-tight leading-tight">Private LLM systems,<br/><span class="text-blue-300">engineered like infrastructure.</span></h1>
-        <p class="mt-8 text-lg text-slate-300 max-w-2xl leading-relaxed">I design and ship enterprise RAG, agentic workflows, and token-efficient AI on cloud-native data platforms with the controls, evaluation, and observability that production demands.</p>
+        <p class="text-xs tracking-widest uppercase text-cyan-300/80 mb-6">GenAI-Driven Data Architect</p>
+        <h1 class="text-4xl md:text-5xl font-black tracking-tight leading-tight">Private LLM systems,<br/><span class="text-cyan-300">engineered like infrastructure.</span></h1>
+        <p class="mt-8 text-base text-slate-300 max-w-2xl leading-relaxed">I design and ship enterprise RAG, agentic workflows, and token-efficient AI on cloud-native data platforms with the controls, evaluation, and observability that production demands.</p>
         <div class="mt-10 flex flex-wrap gap-3">
-          <a href="#systems" class="px-5 py-3 rounded-md bg-blue-500 text-slate-950 font-medium hover:bg-blue-400 transition">See the systems</a>
-          <a href="/contact" class="px-5 py-3 rounded-md border border-slate-700 text-slate-200 hover:border-slate-500 transition">Architectural advisory</a>
+          <a href="#systems" class="px-5 py-3 rounded-full bg-cyan-400 text-slate-950 font-medium hover:bg-cyan-300 transition">See the systems</a>
+          <a href="/contact" class="px-5 py-3 rounded-full border border-slate-700 text-slate-200 hover:border-cyan-400/40 hover:text-cyan-100 transition">Architectural advisory</a>
         </div>
       </div>
       <div class="lg:col-span-5 relative"><HeroNodeGraph /></div>
@@ -32,8 +32,8 @@ const projects = [
     <section id="systems" class="px-6 lg:px-16 py-24 border-t border-slate-800">
       <div class="grid lg:grid-cols-12 gap-12">
         <div class="lg:col-span-4">
-          <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-4">Systems View</p>
-          <h2 class="text-4xl font-semibold tracking-tight">How I think about GenAI in production.</h2>
+          <p class="text-xs tracking-widest uppercase text-cyan-300/80 mb-4">Systems View</p>
+          <h2 class="text-3xl md:text-4xl font-black tracking-tight">How I think about GenAI in production.</h2>
         </div>
         <div class="lg:col-span-8 space-y-6 text-slate-300 leading-relaxed">
           <p>Most GenAI failures are not model failures - they are <span class="text-slate-100">systems failures</span>: weak retrieval, unbounded context, no evaluation, no guardrails.</p>
@@ -46,8 +46,8 @@ const projects = [
     <section class="px-6 lg:px-16 py-24 border-t border-slate-800">
       <div class="flex items-end justify-between mb-12">
         <div>
-          <p class="text-xs tracking-widest uppercase text-blue-300/80 mb-4">Case Studies</p>
-          <h2 class="text-4xl font-semibold tracking-tight">Selected work.</h2>
+          <p class="text-xs tracking-widest uppercase text-cyan-300/80 mb-4">Case Studies</p>
+          <h2 class="text-3xl md:text-4xl font-black tracking-tight">Selected work.</h2>
         </div>
         <a href="/experience" class="hidden md:inline text-sm text-slate-400 hover:text-slate-200">Full experience -></a>
       </div>
@@ -68,9 +68,9 @@ const projects = [
 
     <section class="px-6 lg:px-16 py-24 border-t border-slate-800">
       <div class="max-w-3xl">
-        <h2 class="text-4xl font-semibold tracking-tight">Available for GenAI architectural advisory.</h2>
+        <h2 class="text-3xl md:text-4xl font-black tracking-tight">Available for GenAI architectural advisory.</h2>
         <p class="mt-6 text-slate-300 leading-relaxed">Private LLM apps, enterprise RAG, agentic orchestration, and GCP-native data platforms - from blueprint to production.</p>
-        <a href="/contact" class="inline-block mt-8 px-6 py-3 rounded-md bg-blue-500 text-slate-950 font-medium hover:bg-blue-400 transition">Start a conversation</a>
+        <a href="/contact" class="inline-block mt-8 px-8 py-3.5 rounded-full bg-gradient-to-r from-indigo-500 to-cyan-500 text-slate-950 font-bold transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.25)] hover:scale-[1.03]">Start a conversation</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
…graphy pass

- index.astro: Remove duplicate hero subtitle; keep single <h1 id="hero-headline"> with SplitText animation
- skills.astro: Add group descriptions for GenAI context; replace h-1.5 bars with h-px animated bars respecting prefers-reduced-motion
- experience.astro: Add vertical timeline rule (md+) with indigo dots; mobile falls back to stacked cards
- about.astro: Remove duplicate expertise section and blue gradient artifacts; keep text-3xl/4xl headings max
- v2.astro: Replace blue-500 with cyan-400/indigo-500 palette; reduce headings to text-4xl/5xl; solid CTA buttons