### PR TITLE
Typography tuning, visual diagrams, motion refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@ dist/
 *.log
 .DS_Store
 .opencode
+.codegraph/
+.understand-anything/
+data/
+session-*.md
 graphify-**

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .netlify/
 *.log
 .DS_Store
+.opencode
+graphify-**

--- a/src/components/ExpCard.astro
+++ b/src/components/ExpCard.astro
@@ -13,27 +13,34 @@ interface Props {
 const { role, company, date, summary, chips, metric, metricLabel, index } = Astro.props as Props;
 ---
 
-<article class="exp-card relative" style="perspective: 1000px;">
-  <div class="exp-card-inner relative rounded-3xl border border-slate-700/50 bg-slate-900/80 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)] will-change-transform">
-    <div class="flex flex-col md:flex-row justify-between gap-6 items-start">
+<article
+  class="exp-card sticky rounded-2xl border border-slate-700/50 bg-slate-900/80 p-6 md:p-8 shadow-[0_-8px_40px_rgba(0,0,0,0.6)] origin-top"
+  style={`top: ${4 + index * 1.5}rem; z-index: ${30 - index}; perspective: 1200px;`}
+>
+  <div class="exp-card-inner will-change-transform">
+    <div class="absolute left-0 top-0 bottom-0 w-0.5 bg-gradient-to-b from-indigo-500/40 via-cyan-500/25 to-transparent" aria-hidden="true"></div>
+    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-indigo-500/25 to-transparent" aria-hidden="true"></div>
+
+    <div class="flex flex-col md:flex-row justify-between gap-5 items-start">
       <div class="flex-1 min-w-0">
-        <div class="flex flex-wrap items-center gap-2 mb-4">
-          <span class="font-mono text-[10px] tracking-widest uppercase text-indigo-400/60">{company}</span>
+        <div class="flex flex-wrap items-center gap-2 mb-2">
+          <span class="font-mono text-[10px] uppercase tracking-widest text-indigo-400/60">{company}</span>
+          <span class="font-mono text-[10px] text-slate-600">· {date}</span>
         </div>
-        <h2 class="text-xl md:text-2xl font-bold text-white tracking-tight">{role}</h2>
-        <p class="mt-3 text-sm text-slate-400 leading-relaxed">{summary}</p>
-        <div class="mt-4 flex flex-wrap items-center gap-1.5">
+        <h2 class="text-base md:text-lg font-semibold text-white tracking-tight">{role}</h2>
+        <p class="mt-2 text-xs text-slate-400 leading-relaxed">{summary}</p>
+        <div class="mt-3 flex flex-wrap items-center gap-1.5">
           {chips.split(' · ').map(tag => <span class="rounded border border-slate-700/50 bg-slate-900/50 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{tag}</span>)}
         </div>
         {metric && metricLabel && (
-          <div class="mt-4 pt-3 border-t border-slate-800/40 flex items-baseline gap-2">
-            <span class="font-mono text-sm font-bold text-emerald-400">{metric}</span>
+          <div class="mt-3 pt-3 border-t border-slate-800/40 flex items-baseline gap-2">
+            <span class="font-mono text-xs font-semibold text-emerald-400">{metric}</span>
             <span class="font-mono text-[10px] text-slate-600 uppercase tracking-wider">{metricLabel}</span>
           </div>
         )}
       </div>
-      <div class="flex-shrink-0 w-14 h-14 rounded-2xl border border-indigo-500/15 flex items-center justify-center bg-indigo-500/5 relative">
-        <span class="font-mono text-indigo-400/50 font-bold text-lg">{String(index + 1).padStart(2, '0')}</span>
+      <div class="flex-shrink-0 w-12 h-12 rounded-xl border border-indigo-500/15 flex items-center justify-center bg-indigo-500/5 relative">
+        <span class="font-mono text-indigo-400/50 font-bold text-base">{String(index + 1).padStart(2, '0')}</span>
       </div>
     </div>
   </div>

--- a/src/components/HeroNodeGraph.astro
+++ b/src/components/HeroNodeGraph.astro
@@ -1,8 +1,8 @@
 ---
 // HeroNodeGraph.astro
-// Subtle animated node-graph background for the hero section.
-// Pure SVG + CSS. No external deps. Respects prefers-reduced-motion.
-// SVG groups have IDs for GSAP cursor-parallax (hb-layer-edges, hb-layer-nodes, hb-layer-pulse).
+// Enhanced node-graph background with system labels + breathing nodes.
+// Pure SVG + CSS. Respects prefers-reduced-motion.
+// SVG groups have IDs for GSAP cursor-parallax.
 ---
 
 <div class="hero-bg" aria-hidden="true">
@@ -21,8 +21,8 @@
     <rect width="1440" height="800" fill="url(#hb-grid)" opacity="0.3" />
     <rect width="1440" height="800" fill="url(#hb-glow)" />
 
-    <!-- Layer 1: Edges — moves slowest with cursor (parallax depth 0.3) -->
-    <g id="hb-layer-edges" class="hb-edges" stroke="#334155" stroke-width="0.8" fill="none" opacity="0.5">
+    <!-- Layer 1: Edges — moves slowest with cursor -->
+    <g id="hb-layer-edges" class="hb-edges" stroke="#334155" stroke-width="0.8" fill="none" opacity="0.55">
       <line x1="180" y1="160" x2="420" y2="260" />
       <line x1="420" y1="260" x2="680" y2="180" />
       <line x1="680" y1="180" x2="960" y2="300" />
@@ -34,37 +34,45 @@
       <line x1="420" y1="260" x2="500" y2="460" />
       <line x1="680" y1="180" x2="760" y2="560" />
       <line x1="960" y1="300" x2="1040" y2="480" />
-      <!-- Secondary network -->
       <line x1="100" y1="400" x2="260" y2="540" />
       <line x1="1300" y1="600" x2="1400" y2="500" />
-      <line x1="1240" y1="220" x2="1300" y2="600" opacity="0.3" />
-      <line x1="180" y1="160" x2="260" y2="540" opacity="0.25" />
+      <line x1="1240" y1="220" x2="1300" y2="600" opacity="0.35" />
+      <line x1="180" y1="160" x2="260" y2="540" opacity="0.3" />
     </g>
 
-    <!-- Layer 2: Nodes — moves at medium speed (parallax depth 0.5) -->
+    <!-- Layer 2: Nodes — medium parallax speed -->
     <g id="hb-layer-nodes" class="hb-nodes">
-      <circle cx="180" cy="160" r="3" fill="#818cf8" />
-      <circle cx="420" cy="260" r="3.5" fill="#a5b4fc" />
-      <circle cx="680" cy="180" r="3" fill="#22d3ee" />
-      <circle cx="960" cy="300" r="3.5" fill="#34d399" />
-      <circle cx="1240" cy="220" r="3" fill="#a7f3d0" />
-      <circle cx="260" cy="540" r="3" fill="#818cf8" />
-      <circle cx="500" cy="460" r="3.5" fill="#a5b4fc" />
-      <circle cx="760" cy="560" r="3" fill="#22d3ee" />
-      <circle cx="1040" cy="480" r="3.5" fill="#34d399" />
-      <circle cx="1300" cy="600" r="3" fill="#a7f3d0" />
-      <circle cx="100" cy="400" r="2.5" fill="#6366f1" opacity="0.6" />
-      <circle cx="1400" cy="500" r="2.5" fill="#6366f1" opacity="0.6" />
+      <!-- Primary nodes -->
+      <circle cx="180" cy="160" r="3.5" fill="#818cf8" class="node-breathe" />
+      <circle cx="420" cy="260" r="4" fill="#a5b4fc" class="node-breathe" />
+      <circle cx="680" cy="180" r="3.5" fill="#22d3ee" class="node-breathe" />
+      <circle cx="960" cy="300" r="4" fill="#34d399" class="node-breathe" />
+      <circle cx="1240" cy="220" r="3.5" fill="#a7f3d0" />
+      <circle cx="260" cy="540" r="3.5" fill="#818cf8" />
+      <circle cx="500" cy="460" r="4" fill="#a5b4fc" class="node-breathe" />
+      <circle cx="760" cy="560" r="3.5" fill="#22d3ee" class="node-breathe" />
+      <circle cx="1040" cy="480" r="4" fill="#34d399" />
+      <circle cx="1300" cy="600" r="3.5" fill="#a7f3d0" />
+      <circle cx="100" cy="400" r="3" fill="#6366f1" opacity="0.6" />
+      <circle cx="1400" cy="500" r="3" fill="#6366f1" opacity="0.6" />
     </g>
 
-    <!-- Layer 3: Pulse rings — moves fastest (parallax depth 0.7) -->
+    <!-- System labels — small mono labels on key nodes -->
+    <g class="hb-labels" font-family="JetBrains Mono,monospace" font-size="8" fill="rgba(148,163,184,0.45)" letter-spacing="0.12em">
+      <text x="430" y="250" >DATA</text>
+      <text x="690" y="168" >RAG</text>
+      <text x="775" y="550" >AGENTS</text>
+      <text x="1055" y="470" >GUARD</text>
+    </g>
+
+    <!-- Layer 3: Pulse rings — fastest parallax -->
     <g id="hb-layer-pulse" class="hb-pulse">
-      <circle cx="420" cy="260" r="7" fill="none" stroke="#818cf8" stroke-width="1" />
-      <circle cx="680" cy="180" r="7" fill="none" stroke="#22d3ee" stroke-width="1" />
-      <circle cx="960" cy="300" r="7" fill="none" stroke="#34d399" stroke-width="1" />
-      <circle cx="500" cy="460" r="7" fill="none" stroke="#a5b4fc" stroke-width="1" />
-      <circle cx="760" cy="560" r="7" fill="none" stroke="#22d3ee" stroke-width="1" />
-      <circle cx="1040" cy="480" r="7" fill="none" stroke="#34d399" stroke-width="1" />
+      <circle cx="420" cy="260" r="7" fill="none" stroke="#818cf8" stroke-width="1.2" />
+      <circle cx="680" cy="180" r="7" fill="none" stroke="#22d3ee" stroke-width="1.2" />
+      <circle cx="960" cy="300" r="7" fill="none" stroke="#34d399" stroke-width="1.2" />
+      <circle cx="500" cy="460" r="7" fill="none" stroke="#a5b4fc" stroke-width="1.2" />
+      <circle cx="760" cy="560" r="7" fill="none" stroke="#22d3ee" stroke-width="1.2" />
+      <circle cx="1040" cy="480" r="7" fill="none" stroke="#34d399" stroke-width="1.2" />
     </g>
   </svg>
 </div>
@@ -80,6 +88,21 @@
   }
   .hb-edges line:nth-child(odd) { animation-duration: 26s; animation-direction: reverse; }
   .hb-edges line:nth-child(3n) { animation-duration: 30s; }
+
+  /* Node breathing — gentle opacity pulse on key nodes */
+  .node-breathe {
+    animation: hb-breathe 5s ease-in-out infinite;
+  }
+  .node-breathe:nth-child(2) { animation-delay: 0.5s; }
+  .node-breathe:nth-child(3) { animation-delay: 1.8s; }
+  .node-breathe:nth-child(4) { animation-delay: 3s; }
+  .node-breathe:nth-child(5) { animation-delay: 1.2s; }
+  .node-breathe:nth-child(6) { animation-delay: 2.5s; }
+
+  @keyframes hb-breathe {
+    0%, 100% { opacity: 0.55; }
+    50%      { opacity: 1; }
+  }
 
   /* Pulse rings */
   .hb-pulse circle {
@@ -107,6 +130,7 @@
 
   @media (prefers-reduced-motion: reduce) {
     .hb-edges line,
-    .hb-pulse circle { animation: none; }
+    .hb-pulse circle,
+    .node-breathe { animation: none; }
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-const { title = "Jagadeesh Thiruveedula — GenAI Systems Architect", description = "A premium portfolio for a GenAI-driven data architect building private LLM systems, enterprise RAG, and governed AI workflows on GCP." } = Astro.props;
+const { title = "Jagadeesh Thiruveedula — GenAI Systems Architect", description = "A premium portfolio for a GenAI-driven data architect building private LLM systems, enterprise RAG, and governed AI workflows on GCP.", navLabel } = Astro.props;
 const { pathname } = Astro.url;
 
 const navLinks = [
@@ -179,7 +179,7 @@ function isActive(href: string) {
             <span class="font-mono text-base font-bold text-indigo-400 group-hover:text-indigo-300 transition-colors">
               JT_<span class="logo-cursor" aria-hidden="true"></span>
             </span>
-            <span id="nav-section-label" class="hidden md:inline-block font-mono text-xs text-slate-500 tracking-widest transition-all duration-300"></span>
+            <span id="nav-section-label" class="hidden md:inline-block font-mono text-xs text-slate-500 tracking-widest transition-all duration-300 opacity-40">{navLabel || 'Jagadeesh Thiruveedula'}</span>
           </a>
 
           <!-- Desktop Nav -->
@@ -218,12 +218,12 @@ function isActive(href: string) {
           <!-- Brand block -->
           <div class="flex flex-col gap-3">
             <div class="flex items-baseline gap-3">
-              <span class="footer-mono text-xl font-bold text-indigo-400">JT_</span>
+              <span class="footer-mono text-xl font-semibold text-indigo-400">JT_</span>
               <span class="footer-mono text-xs text-slate-500 tracking-widest">
                 // SYSTEM STATUS: <span class="text-emerald-400" id="footer-status">AVAILABLE</span>
               </span>
             </div>
-            <p class="text-sm text-slate-300 font-semibold mt-1">Jagadeesh Thiruveedula</p>
+            <p class="text-sm text-slate-300 mt-1">Jagadeesh Thiruveedula</p>
             <p class="footer-mono text-xs text-slate-500 leading-relaxed">GenAI Systems Architect<br/>GCP-native · Vertex AI · Enterprise RAG</p>
           </div>
 
@@ -363,6 +363,7 @@ function isActive(href: string) {
       }
 
       /* Global will-change for animated elements */
+      .hero-line,
       .hero-description,
       .stack-card,
       .pipeline-step,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -217,11 +217,8 @@ function isActive(href: string) {
 
           <!-- Brand block -->
           <div class="flex flex-col gap-3">
-            <div class="flex items-baseline gap-3">
+            <div class="flex items-baseline">
               <span class="footer-mono text-xl font-semibold text-indigo-400">JT_</span>
-              <span class="footer-mono text-xs text-slate-500 tracking-widest">
-                // SYSTEM STATUS: <span class="text-emerald-400" id="footer-status">AVAILABLE</span>
-              </span>
             </div>
             <p class="text-sm text-slate-300 mt-1">Jagadeesh Thiruveedula</p>
             <p class="footer-mono text-xs text-slate-500 leading-relaxed">GenAI Systems Architect<br/>GCP-native · Vertex AI · Enterprise RAG</p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,22 +2,22 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="About — Jagadeesh Thiruveedula">
+<Layout title="About — Jagadeesh Thiruveedula" navLabel="Jagadeesh">
   <main class="min-h-screen px-4 py-20 md:px-8 lg:px-12 bg-slate-950 text-slate-100">
     <section class="mx-auto flex w-full max-w-6xl flex-col gap-10">
       <header class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_12px_40px_rgba(2,6,23,0.45)] md:p-10">
-        <p class="section-eyebrow text-amber-300">[MODULE: PROFILE]</p>
+        <p class="section-eyebrow text-amber-300">PROFILE</p>
         <div class="flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
           <div class="flex items-center gap-5">
             <div class="flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-700/70 bg-slate-950 text-xl font-black text-cyan-300">JT</div>
             <div>
-              <h1 class="text-3xl font-black text-white md:text-4xl">About Me</h1>
-              <p class="mt-1 text-sm text-slate-400">GenAI Systems Architect · GCP-native · Enterprise RAG</p>
+              <h1 class="text-2xl font-bold text-white md:text-3xl">About Me</h1>
+              <p class="mt-1 text-xs text-slate-400">GenAI Systems Architect · GCP-native · Enterprise RAG</p>
             </div>
           </div>
           <span class="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-[10px] font-mono uppercase tracking-[0.25em] text-emerald-300">STATUS: AVAILABLE</span>
         </div>
-        <p class="mt-6 max-w-3xl text-sm text-slate-300 leading-relaxed">I design governed AI systems, high-reliability retrieval pipelines, and production-ready cloud architectures for enterprise teams that need confidence, security, and measurable outcomes.</p>
+        <p class="mt-6 max-w-2xl text-xs text-slate-400 leading-relaxed">I design governed AI systems, high-reliability retrieval pipelines, and production-ready cloud architectures for enterprise teams that need confidence, security, and measurable outcomes.</p>
       </header>
 
       <section class="grid grid-cols-2 gap-4 md:grid-cols-4" aria-labelledby="metrics-heading">
@@ -47,23 +47,47 @@ import Layout from '../layouts/Layout.astro';
     <section class="grid grid-cols-1 gap-6 md:grid-cols-3" aria-labelledby="expertise-heading">
       <h2 id="expertise-heading" class="sr-only">Areas of Technical Expertise</h2>
       <article class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)] transition-all duration-300 hover:border-cyan-400/30 hover:-translate-y-0.5">
-        <h3 class="text-base font-bold text-white">Cloud Data Architectures</h3>
-        <p class="mt-3 text-sm text-slate-400 leading-relaxed">Expert in GCP, BigQuery, Dataflow, and multi-cloud lakehouse patterns with enterprise-grade security and scalability.</p>
+        <h3 class="text-sm font-semibold text-white">Cloud Data Architectures</h3>
+        <p class="mt-2 text-xs text-slate-400 leading-relaxed">Expert in GCP, BigQuery, Dataflow, and multi-cloud lakehouse patterns with enterprise-grade security and scalability.</p>
       </article>
       <article class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)] transition-all duration-300 hover:border-cyan-400/30 hover:-translate-y-0.5">
-        <h3 class="text-base font-bold text-white">Enterprise GenAI & Vector Search</h3>
-        <p class="mt-3 text-sm text-slate-400 leading-relaxed">Building private LLM systems, RAG pipelines, and controlled retrieval experiences for production teams.</p>
+        <h3 class="text-sm font-semibold text-white">Enterprise GenAI & Vector Search</h3>
+        <p class="mt-2 text-xs text-slate-400 leading-relaxed">Building private LLM systems, RAG pipelines, and controlled retrieval experiences for production teams.</p>
       </article>
       <article class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)] transition-all duration-300 hover:border-cyan-400/30 hover:-translate-y-0.5">
-        <h3 class="text-base font-bold text-white">Impact & Leadership</h3>
-        <p class="mt-3 text-sm text-slate-400 leading-relaxed">Trusted for modernization, governance, platform design, and delivery across enterprise environments.</p>
+        <h3 class="text-sm font-semibold text-white">Impact & Leadership</h3>
+        <p class="mt-2 text-xs text-slate-400 leading-relaxed">Trusted for modernization, governance, platform design, and delivery across enterprise environments.</p>
       </article>
     </section>
 
+    <!-- Data → Cloud → AI timeline visual -->
+    <div class="flex items-center justify-center gap-0" aria-hidden="true">
+      <div class="flex flex-col items-center gap-2">
+        <div class="w-10 h-10 rounded-xl border border-indigo-500/30 bg-indigo-500/10 flex items-center justify-center">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+        </div>
+        <span class="font-mono text-[10px] text-indigo-400/60 uppercase tracking-widest">Data</span>
+      </div>
+      <div class="w-16 h-px bg-gradient-to-r from-indigo-500/30 to-cyan-400/30"></div>
+      <div class="flex flex-col items-center gap-2">
+        <div class="w-10 h-10 rounded-xl border border-cyan-400/30 bg-cyan-500/10 flex items-center justify-center">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="1.5"><path d="M4 7a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V7z"/><path d="M14 2v4M10 2v4"/></svg>
+        </div>
+        <span class="font-mono text-[10px] text-cyan-400/60 uppercase tracking-widest">Cloud</span>
+      </div>
+      <div class="w-16 h-px bg-gradient-to-r from-cyan-400/30 to-emerald-400/30"></div>
+      <div class="flex flex-col items-center gap-2">
+        <div class="w-10 h-10 rounded-xl border border-emerald-500/30 bg-emerald-500/10 flex items-center justify-center">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+        </div>
+        <span class="font-mono text-[10px] text-emerald-400/60 uppercase tracking-widest">AI</span>
+      </div>
+    </div>
+
     <section class="max-w-3xl text-center" aria-labelledby="cta-heading">
       <div class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)] md:p-10">
-        <h2 id="cta-heading" class="text-2xl font-black text-white md:text-3xl">Ready to Transform Your Data Strategy?</h2>
-        <p class="mt-4 text-sm text-slate-400 leading-relaxed">Let's discuss how cloud modernization and GenAI can drive measurable business impact for your organization.</p>
+        <h2 id="cta-heading" class="text-xl font-bold text-white md:text-2xl">Ready to Transform Your Data Strategy?</h2>
+        <p class="mt-3 text-xs text-slate-400 leading-relaxed">Let's discuss how cloud modernization and GenAI can drive measurable business impact for your organization.</p>
         <div class="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
           <a href="/contact" class="inline-flex items-center justify-center rounded-full bg-cyan-400 px-7 py-3 text-sm font-bold text-slate-950 transition-all duration-200 hover:bg-cyan-300">Get In Touch</a>
           <a href="/experience" class="inline-flex items-center justify-center rounded-full border border-slate-700 bg-slate-900/60 px-7 py-3 text-sm font-semibold text-slate-300 transition-all duration-200 hover:border-cyan-400/40 hover:text-cyan-100">View Experience</a>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Contact | Jagadeesh Thiruveedula">
+<Layout title="Contact | Jagadeesh Thiruveedula" navLabel="Jagadeesh Thiruveedula">
   <section class="relative min-h-screen overflow-hidden bg-slate-950 py-20 text-slate-100">
     <!-- Background Accents -->
     <div class="absolute inset-0 opacity-20">
@@ -12,9 +12,9 @@ import Layout from '../layouts/Layout.astro';
 
     <div class="container relative z-10 mx-auto px-4 max-w-4xl">
       <div class="mb-16 text-center">
-        <p class="section-eyebrow text-amber-300">[MODULE: CONTACT]</p>
-        <h1 class="mt-3 text-3xl font-black text-white md:text-4xl">Let's Build the Future</h1>
-        <p class="text-sm text-slate-400 md:text-base">
+        <p class="section-eyebrow text-amber-300">CONTACT</p>
+        <h1 class="mt-3 text-2xl font-bold text-white md:text-3xl">Let's Build the Future</h1>
+        <p class="text-xs text-slate-400 md:text-sm">
           Interested in GenAI architecture, GCP modernization, or high-scale data engineering? Let's connect.
         </p>
       </div>
@@ -31,7 +31,7 @@ import Layout from '../layouts/Layout.astro';
                 </div>
                 <div>
                   <div class="text-xs text-slate-400">LinkedIn</div>
-                  <div class="font-semibold">Jagadeesh Thiruveedula</div>
+                  <div class="font-medium">Jagadeesh Thiruveedula</div>
                 </div>
               </a>
               
@@ -41,7 +41,7 @@ import Layout from '../layouts/Layout.astro';
                 </div>
                 <div>
                   <div class="text-xs text-slate-400">GitHub</div>
-                  <div class="font-semibold">@jthiruveedula</div>
+                  <div class="font-medium">@jthiruveedula</div>
                 </div>
               </a>
             </div>
@@ -60,32 +60,32 @@ import Layout from '../layouts/Layout.astro';
           </div>
         </div>
 
-        <!-- Professional Summary Card -->
+        <!-- Session Card: pseudo-log of engagement flow -->
         <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)] backdrop-blur-xl">
-          <h3 class="text-base font-bold text-white md:text-lg mb-4">Let's Collaborate</h3>
-          <p class="text-sm text-slate-400 mb-6 leading-relaxed">
-            With 10+ years driving enterprise data transformation and GenAI implementations, I specialize in:
-          </p>
-          <ul class="space-y-3 mb-8">
-            <li class="flex items-start gap-2">
-              <svg class="w-5 h-5 text-cyan-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-              <span class="text-sm">Cloud data platform modernization (AWS to GCP)</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-5 h-5 text-cyan-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-              <span class="text-sm">RAG pipelines & LLM orchestration at scale</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-5 h-5 text-cyan-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-              <span class="text-sm">Enterprise GenAI architecture & governance</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-5 h-5 text-cyan-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-              <span class="text-sm">Cost optimization & performance tuning</span>
-            </li>
-          </ul>
-          <div class="text-sm text-slate-400">
-            <p>Available for consulting, advisory, and full-time opportunities.</p>
+          <div class="flex items-center gap-2 mb-5">
+            <span class="w-2 h-2 rounded-full bg-emerald-400/60"></span>
+            <span class="font-mono text-[10px] uppercase tracking-[0.25em] text-emerald-400/60">Session: Initiate</span>
+          </div>
+          <div class="space-y-3 session-steps">
+            {['Understand current stack', 'Map AI surfaces', 'Ship a governed POC'].map((step, i) => (
+              <div class="session-step flex items-center gap-3 group">
+                <span class="font-mono text-[10px] text-slate-600 w-6 shrink-0">0{i + 1}</span>
+                <div class="h-px flex-1 bg-slate-800/60 group-hover:bg-indigo-500/30 transition-colors"></div>
+                <span class="font-mono text-xs text-slate-400 group-hover:text-slate-200 transition-colors">{step}</span>
+              </div>
+            ))}
+          </div>
+          <div class="mt-6 pt-5 border-t border-slate-800/60">
+            <p class="text-xs text-slate-400 leading-relaxed">
+              With 10+ years driving enterprise data transformation and GenAI implementations.
+            </p>
+            <div class="mt-3 flex flex-wrap gap-1.5">
+              <span class="font-mono text-[10px] px-2 py-0.5 rounded border border-slate-700/50 text-slate-500 bg-slate-900/50">Cloud Modernization</span>
+              <span class="font-mono text-[10px] px-2 py-0.5 rounded border border-slate-700/50 text-slate-500 bg-slate-900/50">RAG & LLM Ops</span>
+              <span class="font-mono text-[10px] px-2 py-0.5 rounded border border-slate-700/50 text-slate-500 bg-slate-900/50">GenAI Governance</span>
+              <span class="font-mono text-[10px] px-2 py-0.5 rounded border border-slate-700/50 text-slate-500 bg-slate-900/50">Cost Optimization</span>
+            </div>
+            <p class="mt-4 text-xs text-slate-500">Available for consulting, advisory, and full-time opportunities.</p>
           </div>
         </article>
       </div>
@@ -102,6 +102,28 @@ import Layout from '../layouts/Layout.astro';
     </div>
   </section>
 </Layout>
+
+<script>
+  import gsap from 'gsap';
+  import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    gsap.from('.session-step', {
+      opacity: 0,
+      x: -12,
+      stagger: 0.15,
+      duration: 0.5,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: '.session-steps',
+        start: 'top 75%',
+        toggleActions: 'play none none none',
+      }
+    });
+  }
+</script>
 
 <style>
   @media (prefers-reduced-motion: reduce) {

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -2,44 +2,42 @@
 import Layout from '../layouts/Layout.astro';
 import ExpCard from '../components/ExpCard.astro';
 
-const workRoles = [
+const allRoles = [
   ['Data Architect','Quantiphi','Sep 2022 – Present','GCP modernization, RAG platforms, evaluation harnesses, and secure enterprise AI delivery.','GCP · GenAI · RAG · IAM','3','production GenAI systems'],
   ['Senior Data Engineer','Charles Schwab','Nov 2021 – Sep 2022','Migrated warehouse workloads to GCP and stabilized CI/CD, observability, and performance at scale.','BigQuery · PySpark · Terraform · DevOps','$MM','cloud migration programs'],
   ['Data Engineer','Wiley Publications','Mar 2019 – Nov 2021','Built ETL pipelines, data integration layers, and analytics workflows for publishing platforms.','ETL · Data Pipelines · Analytics','12+','enterprise pipelines'],
-];
-
-const earlyRoles = [
   ['Software Engineer','DSOgroup TEOTYS','Aug 2018 – Mar 2019','Talend streaming jobs, CDC pipelines, and DR-ready data frameworks.','Talend · ETL · CDC','Real-time','CDC pipelines'],
   ['Software Engineer','Innominds','Jun 2015 – Jul 2018','Warehouse and ETL design with reusable business logic and reliability improvements.','ETL · Talend · Data Quality','50+','data warehouse ETLs'],
   ['Intern','Vizag Steel Plant','Jan 2015 – Mar 2015','SCADA and automation work for monitoring and operational troubleshooting.','IoT · Automation · Monitoring','SCADA','industrial automation'],
 ];
 ---
 
-<Layout title="Experience — Jagadeesh Thiruveedula">
+<Layout title="Experience — Jagadeesh Thiruveedula" navLabel="Thiruveedula">
   <main class="min-h-screen bg-slate-950 px-4 py-20 text-slate-100 md:px-8 lg:px-12">
-    <section class="mx-auto flex w-full max-w-6xl flex-col gap-10">
+    <section class="mx-auto flex w-full max-w-4xl flex-col gap-10">
       <header class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_12px_40px_rgba(2,6,23,0.45)] md:p-10">
-        <p class="section-eyebrow text-amber-300">[MODULE: EXPERIENCE]</p>
-        <h1 class="text-3xl font-black text-white md:text-4xl">Experience Timeline</h1>
-        <p class="mt-3 max-w-3xl text-sm text-slate-400 leading-relaxed">A production-style view of the systems, platforms, and delivery outcomes behind enterprise AI and data modernization work.</p>
+        <p class="section-eyebrow text-amber-300">EXPERIENCE</p>
+        <h1 class="text-2xl font-bold text-white md:text-3xl">Experience Timeline</h1>
+        <p class="mt-3 max-w-3xl text-xs text-slate-400 leading-relaxed">A production-style view of the systems, platforms, and delivery outcomes behind enterprise AI and data modernization work.</p>
       </header>
 
-      <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 md:p-8">
-        <p class="section-eyebrow text-indigo-300">[MODULE: WORK]</p>
-        <div class="mt-6 space-y-5">
-          {workRoles.map((r, i) => <ExpCard role={r[0]} company={r[1]} date={r[2]} summary={r[3]} chips={r[4]} metric={r[5]} metricLabel={r[6]} index={i} />)}
-        </div>
-      </section>
-
-      <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 md:p-8">
-        <p class="section-eyebrow text-cyan-300">[MODULE: EARLY CAREER]</p>
-        <div class="mt-6 space-y-5">
-          {earlyRoles.map((r, i) => <ExpCard role={r[0]} company={r[1]} date={r[2]} summary={r[3]} chips={r[4]} metric={r[5]} metricLabel={r[6]} index={i + workRoles.length} />)}
-        </div>
+      <section class="relative" style="perspective: 1200px;">
+        {allRoles.map((r, i) => (
+          <ExpCard role={r[0]} company={r[1]} date={r[2]} summary={r[3]} chips={r[4]} metric={r[5]} metricLabel={r[6]} index={i} />
+        ))}
       </section>
     </section>
   </main>
 </Layout>
+
+<style>
+  .exp-card {
+    transition: box-shadow 0.35s ease;
+  }
+  .exp-card:hover {
+    box-shadow: 0 16px 48px -20px rgba(99,102,241,0.15);
+  }
+</style>
 
 <script>
   import gsap from 'gsap';
@@ -50,13 +48,38 @@ const earlyRoles = [
   const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (!prefersReduced) {
-    gsap.from('.exp-card-inner', {
-      opacity: 0,
-      y: 24,
-      stagger: 0.1,
-      duration: 0.6,
-      ease: 'power3.out',
-      scrollTrigger: { trigger: '.exp-card', start: 'top 82%', toggleActions: 'play none none none' },
+    const cards = gsap.utils.toArray<HTMLElement>('.exp-card');
+    cards.forEach((card, i) => {
+      if (i === 0) return;
+
+      gsap.fromTo(card,
+        { y: 50, scale: 0.95, opacity: 0.85 },
+        {
+          y: 0, scale: 1, opacity: 1,
+          duration: 1,
+          scrollTrigger: {
+            trigger: card,
+            start: 'top 82%',
+            end: 'top 32%',
+            scrub: true,
+            invalidateOnRefresh: true,
+          }
+        }
+      );
+
+      if (i > 0) {
+        const prevCard = cards[i - 1];
+        gsap.to(prevCard, {
+          scale: 0.97,
+          scrollTrigger: {
+            trigger: card,
+            start: 'top 60%',
+            end: 'top 20%',
+            scrub: true,
+            invalidateOnRefresh: true,
+          }
+        });
+      }
     });
 
     document.querySelectorAll('.exp-card').forEach((card) => {
@@ -68,8 +91,8 @@ const earlyRoles = [
         const y = ev.clientY - rect.top;
         const halfW = rect.width / 2;
         const halfH = rect.height / 2;
-        const rotateY = ((x - halfW) / halfW) * 2;
-        const rotateX = ((halfH - y) / halfH) * 2;
+        const rotateY = ((x - halfW) / halfW) * 1.5;
+        const rotateX = ((halfH - y) / halfH) * 1.5;
         gsap.to(inner, { rotateX, rotateY, duration: 0.4, ease: 'power2.out', overwrite: 'auto' });
       });
       card.addEventListener('mouseleave', () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -111,33 +111,34 @@ const capabilityCards = [
       <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_40%,rgba(2,6,23,0.7)_100%)]"></div>
     </div>
 
-    <div class="container relative z-10 mx-auto px-4 md:px-6 py-24">
-      <div class="mx-auto flex max-w-5xl flex-col items-start gap-6">
+      <div class="container relative z-10 mx-auto px-4 md:px-6 py-24">
+      <div class="mx-auto flex max-w-3xl flex-col items-start gap-4">
 
-        <!-- H1 — split into words for stagger reveal -->
-        <h1 id="hero-headline" class="hero-title font-black tracking-tight text-white" style="font-size: clamp(1.75rem, 1rem + 2.5vw, 3.5rem); line-height: 1.1;">
-          Command Surface for Production AI
+        <!-- H1 — two-line with line stagger -->
+        <h1 id="hero-headline" class="hero-title font-bold tracking-tight text-white" style="font-size: clamp(1.5rem, 1rem + 2vw, 2.75rem); line-height: 1.2;">
+          <span class="hero-line">Command Surface</span>
+          <span class="hero-line">for Production AI</span>
         </h1>
 
         <!-- Description -->
-        <p class="hero-description max-w-2xl text-base text-slate-300 font-light leading-relaxed md:text-lg">
+        <p class="hero-description max-w-lg text-sm text-slate-300 font-light leading-relaxed md:text-base">
           Private LLM applications, enterprise-grade RAG pipelines, and governed agentic workflows on GCP — built for teams that need performance, security, and operational clarity.
         </p>
 
         <!-- Tag pills -->
-        <div class="hero-tags flex flex-wrap items-center gap-2 mt-2">
+        <div class="hero-tags flex flex-wrap items-center gap-2 mt-1">
           {['GCP-native', 'Vertex AI', 'Token-efficient', 'Governed workflows'].map((item) => (
             <span class="sys-chip">{item}</span>
           ))}
         </div>
 
         <!-- CTAs -->
-        <div class="hero-ctas flex flex-wrap items-center gap-4 mt-4">
-          <a href="#deployments" class="btn-primary inline-flex items-center gap-2 rounded-full bg-cyan-400 px-7 py-3 text-sm font-bold text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.18)] hover:bg-cyan-300 hover:scale-[1.02] transition-all duration-200">
+        <div class="hero-ctas flex flex-wrap items-center gap-4 mt-3">
+          <a href="#deployments" class="btn-primary inline-flex items-center gap-2 rounded-full bg-cyan-400 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.18)] hover:bg-cyan-300 hover:scale-[1.02] transition-all duration-200">
             See the systems
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
-          <a href="/contact" class="btn-primary inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900/60 px-7 py-3 text-sm font-semibold text-slate-300 hover:border-cyan-400/40 hover:text-cyan-100 backdrop-blur-sm transition-all duration-200">
+          <a href="/contact" class="btn-primary inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900/60 px-6 py-2.5 text-sm font-medium text-slate-300 hover:border-cyan-400/40 hover:text-cyan-100 backdrop-blur-sm transition-all duration-200">
             Discuss a system
           </a>
         </div>
@@ -165,11 +166,11 @@ const capabilityCards = [
       <div class="container mx-auto px-4 md:px-6 grid md:grid-cols-2 gap-12 items-center">
         <!-- Copy -->
         <div class="max-w-xl z-10">
-          <p class="section-eyebrow text-amber-400/80">[MODULE: TENSION]</p>
-          <h2 class="text-4xl md:text-5xl lg:text-6xl font-black text-white leading-[1.05] complexity-text">
+          <p class="section-eyebrow text-amber-400/80">TENSION</p>
+          <h2 class="text-2xl md:text-3xl font-bold text-white leading-snug complexity-text">
             The gap between a demo and production is <em class="not-italic text-slate-400">governance.</em>
           </h2>
-          <p class="mt-6 text-lg text-slate-400 leading-relaxed complexity-subtext">
+          <p class="mt-4 text-sm text-slate-400 leading-relaxed max-w-md complexity-subtext">
             Enterprise data is messy. APIs are unpredictable. Without orchestration, AI is just a parlor trick. I bring the discipline of data architecture to generative models.
           </p>
           <!-- Phase indicator -->
@@ -179,8 +180,14 @@ const capabilityCards = [
           </div>
         </div>
 
-        <!-- Governance narrative SVG visualization -->
-        <div class="relative h-[380px] w-full flex items-center justify-center tension-viz" aria-hidden="true">
+        <!-- Label + Governance narrative SVG visualization -->
+        <div class="flex flex-col items-center gap-3">
+          <div class="flex items-center gap-8 font-mono text-[10px] uppercase tracking-[0.2em]">
+            <span class="text-amber-500/50">Demo</span>
+            <span class="w-16 h-px bg-slate-700/40"></span>
+            <span class="text-emerald-400/50">Production</span>
+          </div>
+          <div class="relative h-[340px] w-full flex items-center justify-center tension-viz" aria-hidden="true">
           <svg class="tension-svg w-full max-w-[520px]" viewBox="0 0 520 380" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <filter id="node-glow">
@@ -243,13 +250,14 @@ const capabilityCards = [
         </div>
       </div>
     </div>
+    </div>
   </section>
 
 
   <!-- ═══════════════════════════════════════════════════════════════
        §3 · PIPELINE — Architectural Clarity
   ═══════════════════════════════════════════════════════════════ -->
-  <section class="orchestration-section bg-slate-900 py-32 border-t border-slate-800/40 relative overflow-hidden">
+  <section class="orchestration-section bg-slate-900 py-24 border-t border-slate-800/40 relative overflow-hidden">
     <!-- Animated blueprint background -->
     <div class="absolute inset-0 pointer-events-none overflow-hidden" aria-hidden="true">
       <svg class="w-full h-full" xmlns="http://www.w3.org/2000/svg">
@@ -264,9 +272,9 @@ const capabilityCards = [
 
     <div class="container relative z-10 mx-auto px-4 md:px-6">
       <div class="mb-16 max-w-3xl">
-        <p class="section-eyebrow text-emerald-400">[MODULE: PIPELINE]</p>
-        <h2 class="text-4xl font-black text-white md:text-5xl">Architectural clarity.</h2>
-        <p class="mt-4 text-xl text-slate-400 font-light">How raw data becomes trusted, served intelligence.</p>
+        <p class="section-eyebrow text-emerald-400">PIPELINE</p>
+        <h2 class="text-2xl font-bold text-white md:text-3xl">Architectural clarity.</h2>
+        <p class="mt-2 text-sm text-slate-400 font-light">How raw data becomes trusted, served intelligence.</p>
       </div>
 
       <!-- Pipeline card grid -->
@@ -280,17 +288,17 @@ const capabilityCards = [
           {pipelineStages.map((stage, index) => (
             <div class={`pipeline-step step-${index} relative z-10 flex flex-col gap-4 opacity-0 translate-y-4`} style={`will-change:transform;`}>
               <!-- Card -->
-              <div class="rounded-2xl border border-slate-700/60 bg-slate-950/70 backdrop-blur-sm p-5 flex flex-col gap-3 h-full hover:border-opacity-100 transition-colors duration-300 group"
+              <div class="rounded-2xl border border-slate-700/60 bg-slate-950/70 backdrop-blur-sm p-4 flex flex-col gap-2 h-full hover:border-opacity-100 transition-colors duration-300 group"
                    style={`--step-color: ${stage.color};`}>
 
                 <!-- Step number + active dot -->
                 <div class="flex items-center justify-between">
-                  <span class="font-mono text-3xl font-bold leading-none step-number" style={`color: ${stage.color}; opacity: 0.25;`}>{stage.num}</span>
+                  <span class="font-mono text-2xl font-bold leading-none step-number" style={`color: ${stage.color}; opacity: 0.25;`}>{stage.num}</span>
                   <span class="step-status h-1.5 w-1.5 rounded-full bg-slate-700 transition-colors duration-300"></span>
                 </div>
 
                 <!-- Name -->
-                <h3 class="text-base font-bold text-white tracking-tight">{stage.name}</h3>
+                <h3 class="text-sm font-semibold text-white tracking-tight">{stage.name}</h3>
 
                 <!-- Description -->
                 <p class="text-xs text-slate-500 leading-relaxed flex-1">{stage.desc}</p>
@@ -313,18 +321,18 @@ const capabilityCards = [
   <!-- ═══════════════════════════════════════════════════════════════
        §4 · CAPABILITIES — Systems Expertise (stacking cards)
   ═══════════════════════════════════════════════════════════════ -->
-  <section class="capabilities-section bg-slate-950 py-32 relative border-t border-slate-800/40">
+  <section class="capabilities-section bg-slate-950 py-24 relative border-t border-slate-800/40">
     <div class="container mx-auto px-4 md:px-6 max-w-4xl">
       <div class="mb-16">
-        <p class="section-eyebrow text-indigo-400">[MODULE: CAPABILITIES]</p>
-        <h2 class="text-4xl font-black text-white md:text-5xl">Systems expertise.</h2>
+        <p class="section-eyebrow text-indigo-400">CAPABILITIES</p>
+        <h2 class="text-2xl font-bold text-white md:text-3xl">Systems expertise.</h2>
       </div>
 
       <div class="stacking-container relative" style="perspective: 1200px;">
         {capabilityCards.map(({ num, title, desc, tags, detail }, index) => (
           <article
-            class={`capability-card stack-card sticky mb-6 rounded-3xl border border-slate-700/50 bg-slate-900/80 p-8 md:p-10 shadow-[0_-8px_40px_rgba(0,0,0,0.6)] origin-top relative`}
-            style={`top: ${4 + index * 1.5}rem; z-index: ${index + 10};`}
+            class={`capability-card stack-card sticky mb-4 rounded-2xl border border-slate-700/50 bg-slate-900/80 p-6 md:p-8 shadow-[0_-8px_40px_rgba(0,0,0,0.6)] origin-top relative`}
+            style={`top: ${3 + index * 1}rem; z-index: ${index + 10};`}
           >
             <div class="cap-card-inner will-change-transform">
               <!-- Left accent strip -->
@@ -332,21 +340,29 @@ const capabilityCards = [
               <!-- Top accent line -->
               <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-indigo-500/25 to-transparent" aria-hidden="true"></div>
 
-              <div class="flex flex-col md:flex-row justify-between gap-8 items-start">
+              <div class="flex flex-col md:flex-row justify-between gap-6 items-start">
                 <div class="flex-1 min-w-0">
                   <div class="flex flex-wrap items-center gap-2 mb-4">
                     <span class="font-mono text-[10px] tracking-widest uppercase text-indigo-400/60">{tags}</span>
                   </div>
-                  <h2 class="mb-3 text-xl md:text-2xl font-bold text-white tracking-tight">{title}</h2>
-                  <p class="text-sm text-slate-400 leading-relaxed max-w-lg">{desc}</p>
-                  <div class="mt-5 pt-4 border-t border-slate-800/40">
-                    <p class="font-mono text-xs text-slate-600 leading-relaxed">{detail}</p>
+                  <h2 class="mb-2 text-base md:text-lg font-semibold text-white tracking-tight">{title}</h2>
+                  <p class="text-xs text-slate-400 leading-relaxed max-w-md">{desc}</p>
+                  <div class="mt-3 pt-3 border-t border-slate-800/40">
+                    <p class="font-mono text-[10px] text-slate-600 leading-relaxed">{detail}</p>
                   </div>
                 </div>
 
-                <div class="flex-shrink-0 w-14 h-14 rounded-2xl border border-indigo-500/15 flex items-center justify-center bg-indigo-500/5 relative">
+                <div class="flex-shrink-0 w-12 h-12 rounded-xl border border-indigo-500/15 flex items-center justify-center bg-indigo-500/5 relative">
                   <span class="absolute -top-2 -right-2 font-mono text-[10px] uppercase tracking-[0.25em] text-amber-300/50">0{index + 1}</span>
-                  <span class="font-mono text-indigo-400/50 font-bold text-lg">{num}</span>
+                  {index === 0 && (
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/><path d="M8 10h8M8 14h6"/></svg>
+                  )}
+                  {index === 1 && (
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><path d="M4 7a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V7z"/><path d="M14 2v4M10 2v4M4 12h16"/></svg>
+                  )}
+                  {index === 2 && (
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><circle cx="12" cy="12" r="3"/><path d="M12 2v7M12 15v7M2 12h7M15 12h7"/></svg>
+                  )}
                 </div>
               </div>
             </div>
@@ -360,15 +376,15 @@ const capabilityCards = [
   <!-- ═══════════════════════════════════════════════════════════════
        §5 · DEPLOYMENTS — Production Proof
   ═══════════════════════════════════════════════════════════════ -->
-  <section id="deployments" class="deployments-section bg-slate-900 py-32 border-t border-slate-800/40 relative overflow-hidden">
+  <section id="deployments" class="deployments-section bg-slate-900 py-24 border-t border-slate-800/40 relative overflow-hidden">
     <!-- Canvas background for constellation hover effect -->
     <canvas id="constellation-canvas" class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"></canvas>
 
     <div class="container relative z-10 mx-auto px-4 md:px-6">
       <div class="mb-16 flex items-end justify-between gap-8">
         <div>
-          <p class="section-eyebrow text-cyan-400">[MODULE: DEPLOYMENTS]</p>
-          <h2 class="text-4xl font-black text-white md:text-5xl">Production-facing AI work.</h2>
+          <p class="section-eyebrow text-cyan-400">DEPLOYMENTS</p>
+          <h2 class="text-2xl font-bold text-white md:text-3xl">Production-facing AI work.</h2>
         </div>
         <a href="/experience" class="hidden md:inline-flex items-center gap-1.5 font-mono text-sm text-slate-500 hover:text-slate-300 transition-colors whitespace-nowrap">
           Full experience <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
@@ -392,7 +408,7 @@ const capabilityCards = [
             </div>
 
             <!-- Title -->
-            <h3 class="text-lg font-bold text-white mb-2 group-hover:text-cyan-100 transition-colors duration-300 pr-8">{title}</h3>
+            <h3 class="text-base font-semibold text-white mb-2 group-hover:text-cyan-100 transition-colors duration-300 pr-8">{title}</h3>
             <p class="text-sm text-slate-500 leading-relaxed mb-5">{summary}</p>
 
             <!-- Stack chips -->
@@ -402,10 +418,17 @@ const capabilityCards = [
               ))}
             </div>
 
-            <!-- Metric -->
-            <div class="pt-4 border-t border-slate-800/60">
-              <span class="metric-value font-mono text-2xl font-bold text-emerald-400 proof-metric" data-value="{metric}">{metric}</span>
-              <span class="font-mono text-xs text-slate-600 ml-2">{metricLabel}</span>
+            <!-- Metric with micro bar -->
+            <div class="pt-3 border-t border-slate-800/60">
+              <div class="relative">
+                <div class="metric-bar-bg absolute -bottom-0.5 left-0 right-0 h-[3px] bg-slate-800/60 rounded-full overflow-hidden">
+                  <div class="metric-bar-fill h-full bg-gradient-to-r from-emerald-500/30 to-cyan-400/30 rounded-full" style="width:0%"></div>
+                </div>
+                <div class="relative flex items-baseline gap-2">
+                  <span class="metric-value font-mono text-base font-semibold text-emerald-400 proof-metric" data-value="{metric}">{metric}</span>
+                  <span class="font-mono text-[10px] text-slate-600">{metricLabel}</span>
+                </div>
+              </div>
             </div>
           </article>
         ))}
@@ -417,7 +440,7 @@ const capabilityCards = [
   <!-- ═══════════════════════════════════════════════════════════════
        §6 · INITIATE — Contact CTA
   ═══════════════════════════════════════════════════════════════ -->
-  <section class="contact-section bg-slate-950 py-40 border-t border-slate-800/40 relative overflow-hidden">
+  <section class="contact-section bg-slate-950 py-32 border-t border-slate-800/40 relative overflow-hidden">
     <!-- Breathing pulse background -->
     <div class="absolute inset-0 flex items-center justify-center pointer-events-none" aria-hidden="true">
       <svg width="600" height="600" viewBox="0 0 600 600" class="cta-pulse-svg">
@@ -429,12 +452,12 @@ const capabilityCards = [
     </div>
 
     <div class="container mx-auto px-4 md:px-6 relative z-10 text-center">
-      <article class="contact-card mx-auto max-w-3xl rounded-3xl border border-slate-700/40 bg-slate-900/50 backdrop-blur-xl p-12 md:p-16 shadow-[0_0_60px_rgba(0,0,0,0.5)] opacity-0 translate-y-6">
-        <p class="section-eyebrow text-cyan-400 text-center">[MODULE: INITIATE]</p>
-        <h2 class="text-3xl font-black text-white md:text-5xl mb-5 tracking-tight">
+      <article class="contact-card mx-auto max-w-3xl rounded-3xl border border-slate-700/40 bg-slate-900/50 backdrop-blur-xl p-10 md:p-12 shadow-[0_0_60px_rgba(0,0,0,0.5)] opacity-0 translate-y-6">
+        <p class="section-eyebrow text-cyan-400 text-center">INITIATE</p>
+        <h2 class="text-2xl font-bold text-white md:text-3xl mb-4 tracking-tight">
           Architecting your next AI system?
         </h2>
-        <p class="text-lg text-slate-400 mb-10 leading-relaxed max-w-xl mx-auto">
+        <p class="text-sm text-slate-400 mb-8 leading-relaxed max-w-lg mx-auto">
           Available for architectural advisory, systems design, and production AI engagements. GCP-native by default.
         </p>
 
@@ -497,6 +520,7 @@ const capabilityCards = [
     .scroll-line {
       animation: none;
     }
+    .hero-line,
     .hero-description,
     .hero-tags,
     .hero-ctas {
@@ -512,6 +536,8 @@ const capabilityCards = [
       transform: none !important;
       box-shadow: none !important;
     }
+    .metric-bar-fill { width: 0 !important; }
+    .session-step { opacity: 1 !important; transform: none !important; }
   }
 </style>
 
@@ -526,12 +552,13 @@ const capabilityCards = [
   // SECTION-AWARE NAV LABEL
   // ─────────────────────────────────────────────────────────────────
   const navLabel = document.getElementById('nav-section-label');
+  const names = ['Jagadeesh', 'Thiruveedula', 'J. T.', 'Jagadeesh T.', 'Jagadeesh Thiruveedula'];
   const sectionDefs = [
-    { trigger: '.complexity-section',   label: '/ TENSION'      },
-    { trigger: '.orchestration-section',label: '/ PIPELINE'     },
-    { trigger: '.capabilities-section', label: '/ CAPABILITIES' },
-    { trigger: '.deployments-section',  label: '/ DEPLOYMENTS'  },
-    { trigger: '.contact-section',      label: '/ INITIATE'     },
+    { trigger: '.complexity-section',   label: names[0] },
+    { trigger: '.orchestration-section',label: names[1] },
+    { trigger: '.capabilities-section', label: names[2] },
+    { trigger: '.deployments-section',  label: names[3] },
+    { trigger: '.contact-section',      label: names[4] },
   ];
 
   if (navLabel) {
@@ -556,27 +583,20 @@ const capabilityCards = [
 
   if (!prefersReduced) {
 
-    const heroH1 = document.getElementById('hero-headline');
-    if (heroH1) {
-      const txt = heroH1.textContent || '';
-      heroH1.textContent = '';
-      const words = txt.split(/\s+/);
-      heroH1.innerHTML = words.map((w, i) => `<span class="hero-word" style="display:inline-block">${w}${i < words.length - 1 ? '\u00A0' : ''}</span>`).join('');
-      gsap.from(heroH1.querySelectorAll('.hero-word'), { opacity: 0, y: 40, rotateX: -90, duration: 0.8, stagger: 0.06, ease: 'power4.out' });
-    }
-    gsap.from('.hero-description', { opacity: 0, y: 20, duration: 0.8, delay: 0.6, ease: 'power3.out' });
+    gsap.from('.hero-line', { opacity: 0, y: 30, rotateX: -45, duration: 0.8, stagger: 0.08, ease: 'power4.out' });
+    gsap.from('.hero-description', { opacity: 0, y: 15, duration: 0.8, delay: 0.5, ease: 'power3.out' });
     const tlHero = gsap.timeline({ defaults: { ease: 'power3.out' } });
 
     // Set initial states
-    gsap.set(['.hero-description', '.hero-ctas'], { y: 18, opacity: 0 });
-    gsap.set('.hero-tags',        { y: 10, opacity: 0 });
+    gsap.set(['.hero-description', '.hero-ctas'], { y: 12, opacity: 0 });
+    gsap.set('.hero-tags',        { y: 8, opacity: 0 });
     gsap.set('.scroll-indicator', { opacity: 0 });
 
     tlHero
-      .to('.hero-description', { y: 0, opacity: 1, duration: 0.7 })
-      .to('.hero-tags',        { y: 0, opacity: 1, duration: 0.5 }, '-=0.5')
-      .to('.hero-ctas',        { y: 0, opacity: 1, duration: 0.5 }, '-=0.4')
-      .to('.scroll-indicator', { opacity: 1, duration: 0.6 }, '-=0.2');
+      .to('.hero-description', { y: 0, opacity: 1, duration: 0.6 })
+      .to('.hero-tags',        { y: 0, opacity: 1, duration: 0.4 }, '-=0.4')
+      .to('.hero-ctas',        { y: 0, opacity: 1, duration: 0.4 }, '-=0.3')
+      .to('.scroll-indicator', { opacity: 1, duration: 0.4 }, '-=0.15');
 
     // ── Cursor parallax on HeroNodeGraph SVG layers ──
     const heroSection  = document.querySelector('.hero-section') as HTMLElement;
@@ -597,9 +617,9 @@ const capabilityCards = [
         const dx = (e.clientX - rect.width  / 2) / rect.width;   // -0.5 → 0.5
         const dy = (e.clientY - rect.height / 2) / rect.height;  // -0.5 → 0.5
 
-        qxE(dx * 18);  qyE(dy * 12);
-        qxN(dx * 30);  qyN(dy * 20);
-        qxP(dx * 42);  qyP(dy * 28);
+        qxE(dx * 12);  qyE(dy * 8);
+        qxN(dx * 20);  qyN(dy * 14);
+        qxP(dx * 30);  qyP(dy * 20);
       }, { passive: true });
 
       heroSection.addEventListener('mouseleave', () => {
@@ -610,7 +630,7 @@ const capabilityCards = [
     // ── Hero scroll-out parallax (SVG dims as hero exits) ──
     gsap.to('#hero-node-svg', {
       opacity: 0,
-      scale: 1.06,
+      scale: 1.03,
       scrollTrigger: {
         trigger: '.hero-section',
         start: 'top top',
@@ -718,9 +738,9 @@ const capabilityCards = [
       const rect = btn.getBoundingClientRect();
       const x = e.clientX - rect.left - rect.width / 2;
       const y = e.clientY - rect.top - rect.height / 2;
-      gsap.to(btn, { x: x * 0.25, y: y * 0.25, duration: 0.25, ease: 'power2.out' });
+      gsap.to(btn, { x: x * 0.15, y: y * 0.15, duration: 0.3, ease: 'power2.out' });
     });
-    btn.addEventListener('mouseleave', () => gsap.to(btn, { x: 0, y: 0, duration: 0.45, ease: 'elastic.out(1, 0.45)' }));
+    btn.addEventListener('mouseleave', () => gsap.to(btn, { x: 0, y: 0, duration: 0.4, ease: 'power3.out' }));
   });
 
   function parseMetricValue(raw: string) {
@@ -760,21 +780,13 @@ const capabilityCards = [
   // ─────────────────────────────────────────────────────────────────
   // §4 · CAPABILITIES — stacking cards with depth scaling
   // ─────────────────────────────────────────────────────────────────
-  gsap.from('.capability-card', {
-    opacity: 0,
-    y: 60,
-    stagger: 0.2,
-    duration: 0.9,
-    ease: 'power3.out',
-    scrollTrigger: { trigger: '.capabilities-section', start: 'top 75%' },
-  });
-
+  // §4 · CAPABILITIES — reduced depth stacking
   const cards = gsap.utils.toArray<HTMLElement>('.stack-card');
   cards.forEach((card, i) => {
-    if (i === 0) return; // First card is always visible
+    if (i === 0) return;
 
     gsap.fromTo(card,
-      { y: 80, scale: 0.96, opacity: 0.85 },
+      { y: 40, scale: 0.97, opacity: 0.9 },
       {
         y: 0, scale: 1, opacity: 1,
         duration: 1,
@@ -788,11 +800,10 @@ const capabilityCards = [
       }
     );
 
-    // Scale down previous cards as next one stacks
     if (i > 0) {
       const prevCard = cards[i - 1];
       gsap.to(prevCard, {
-        scale: 0.97,
+        scale: 0.98,
         scrollTrigger: {
           trigger: card,
           start: 'top 60%',
@@ -815,8 +826,8 @@ const capabilityCards = [
         const y = ev.clientY - rect.top;
         const halfW = rect.width / 2;
         const halfH = rect.height / 2;
-        const rotateY = ((x - halfW) / halfW) * 2;
-        const rotateX = ((halfH - y) / halfH) * 2;
+        const rotateY = ((x - halfW) / halfW) * 1.5;
+        const rotateX = ((halfH - y) / halfH) * 1.5;
         gsap.to(inner, { rotateX, rotateY, duration: 0.4, ease: 'power2.out', overwrite: 'auto' });
       });
       card.addEventListener('mouseleave', () => {
@@ -955,6 +966,26 @@ const capabilityCards = [
     resize();
   })();
 
+
+  // ─────────────────────────────────────────────────────────────────
+  // §5b · DEPLOYMENTS — metric micro-bar fill
+  // ─────────────────────────────────────────────────────────────────
+  document.querySelectorAll('.proof-card').forEach((card, index) => {
+    const bar = card.querySelector('.metric-bar-fill') as HTMLElement;
+    if (!bar) return;
+    const pct = 30 + (index * 12) % 60; // varied fill between 30-90%
+    gsap.to(bar, {
+      width: pct + '%',
+      duration: 1.2,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: card,
+        start: 'top 80%',
+        toggleActions: 'play none none none',
+        invalidateOnRefresh: true,
+      }
+    });
+  });
 
   // ─────────────────────────────────────────────────────────────────
   // §6 · CONTACT CTA — slide in

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -1,71 +1,214 @@
 ---
 import Layout from '../layouts/Layout.astro';
+
+interface SkillIcon {
+  name: string;
+  tag: string;
+  color: string;
+  icon: string; // SVG path data
+}
+
+const platformIcons: SkillIcon[] = [
+  {
+    name: 'GCP', tag: 'Cloud Platform', color: '#22d3ee',
+    icon: 'M5 15a4 4 0 0 1 0-8 4 4 0 0 1 7.4-2A3 3 0 0 1 16 9.5a2.5 2.5 0 0 1 0 5H5Z',
+  },
+  {
+    name: 'BigQuery', tag: 'Data Warehouse', color: '#818cf8',
+    icon: 'M4 7h16M4 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2M4 7v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7M4 12h16',
+  },
+  {
+    name: 'Dataflow', tag: 'Stream Processing', color: '#34d399',
+    icon: 'M3 17l5-5 4 5 5-7 4 4',
+  },
+  {
+    name: 'Vertex AI', tag: 'Machine Learning', color: '#a78bfa',
+    icon: 'M12 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM6 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM18 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM12 20a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM7 7l5 4ZM17 7l-5 4ZM7 17l5-4ZM17 17l5-4Z',
+  },
+  {
+    name: 'Cloud Run', tag: 'Serverless', color: '#38bdf8',
+    icon: 'M8 4v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V4M8 4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2M8 4H6M16 4h2M9 14h6',
+  },
+  {
+    name: 'Terraform', tag: 'Infrastructure as Code', color: '#f59e0b',
+    icon: 'M5 20V9l7-4 7 4v11M5 20h14M5 20H3M19 20h2M12 9v4',
+  },
+];
+
+const aiIcons: SkillIcon[] = [
+  {
+    name: 'RAG', tag: 'Retrieval Augmented', color: '#34d399',
+    icon: 'M7 4h6l4 4v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2ZM14 8V4M9 13l2 2 4-4',
+  },
+  {
+    name: 'LLM Ops', tag: 'Lifecycle', color: '#818cf8',
+    icon: 'M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8ZM12 2v2M12 20v2M2 12h2M20 12h2',
+  },
+  {
+    name: 'Vector Search', tag: 'Similarity', color: '#22d3ee',
+    icon: 'M4 20L12 4l8 16M8 13l8-2M8 13l2 6M16 11l2 6',
+  },
+  {
+    name: 'Eval Harness', tag: 'Evaluation', color: '#fbbf24',
+    icon: 'M12 2a10 10 0 1 0 10 10M12 2v10l6 6M12 2a10 10 0 0 1 10 10',
+  },
+  {
+    name: 'Guardrails', tag: 'Safety', color: '#34d399',
+    icon: 'M12 2l8 4v6a8 8 0 0 1-8 8 8 8 0 0 1-8-8V6l8-4ZM9 12l2 2 4-4',
+  },
+  {
+    name: 'Observability', tag: 'Monitoring', color: '#38bdf8',
+    icon: 'M2 20h20M4 16l4-8 4 4 4-6 4 8',
+  },
+];
+
+const certs = [
+  ['Google Cloud Certified — Professional Data Engineer', 'GCP · BigQuery · Dataflow · AI/ML', 'google'],
+  ['Talend Data Explorer Certification', 'Big Data · ETL · CDC', 'talend'],
+  ['CCA Spark and Hadoop Developer', 'PySpark · Hadoop · Big Data', 'spark'],
+  ['Advanced Certificate in Blockchain — IIIT Hyderabad', 'DLT · Security · Enterprise Blockchain', 'blockchain'],
+  ['Globee Award — IT World Awards\u00ae', 'Leadership · Innovation · Transformation', 'award'],
+];
+
+const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python','SQL','Terraform','Cloud Run','LangGraph','Postgres'];
 ---
 
-<Layout title="Skills & Certifications — Jagadeesh Thiruveedula">
+<Layout title="Skills & Certifications — Jagadeesh Thiruveedula" navLabel="J. T.">
   <main class="min-h-screen bg-slate-950 px-4 py-20 text-slate-100 md:px-8 lg:px-12">
     <section class="mx-auto flex w-full max-w-6xl flex-col gap-10">
+
       <header class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_12px_40px_rgba(2,6,23,0.45)] md:p-10">
-        <p class="section-eyebrow text-amber-300">[MODULE: SKILLS]</p>
-        <h1 class="text-3xl font-black text-white md:text-4xl">Skills & Certifications</h1>
-        <p class="mt-3 max-w-3xl text-sm text-slate-400 leading-relaxed">A compact systems view of the cloud, data, AI, and automation stack behind enterprise delivery.</p>
+        <p class="section-eyebrow text-amber-300">SKILLS</p>
+        <h1 class="text-2xl font-bold text-white md:text-3xl">Skills & Certifications</h1>
+        <p class="mt-3 max-w-3xl text-xs text-slate-400 leading-relaxed">A compact systems view of the cloud, data, AI, and automation stack behind enterprise delivery.</p>
       </header>
 
+      <!-- ════════════════════════════════════════
+           Concept tiles — visual storytelling
+      ════════════════════════════════════════ -->
       <section class="grid gap-6 md:grid-cols-2">
+        <!-- Platform & Cloud -->
         <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-          <h2 class="text-sm font-bold text-white">Platform & Cloud</h2>
-          <div class="mt-5 space-y-5">
-            {['GCP', 'BigQuery', 'Dataflow', 'Vertex AI', 'Cloud Run', 'Terraform'].map((item, i) => (
-              <div class="skill-bar" data-percent={[95, 88, 82, 78, 74, 70][i]}>
-                <div class="mb-1 flex items-center justify-between text-[11px] font-mono text-slate-400"><span>{item}</span><span>{[95, 88, 82, 78, 74, 70][i]}%</span></div>
-                <div class="h-px bg-slate-800/80 overflow-hidden"><div class="skill-bar-fill h-px bg-gradient-to-r from-cyan-400 via-indigo-400 to-emerald-400" style="width:0%"></div></div>
+          <h2 class="text-xs font-semibold text-white flex items-center gap-2 mb-5">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg>
+            Platform & Cloud
+          </h2>
+          <div class="grid gap-3">
+            {platformIcons.map(({ name, tag, color, icon: svg }) => (
+              <div class="skill-tile group flex items-center gap-3 rounded-xl border border-slate-800/40 bg-slate-950/40 p-3 transition-all duration-300 hover:border-slate-700/60 hover:bg-slate-900/60">
+                <!-- Conceptual icon -->
+                <div class="skill-icon shrink-0 w-9 h-9 rounded-lg border border-slate-700/40 bg-slate-900/60 flex items-center justify-center" style={`border-color: ${color}20;`}>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="skill-icon-svg">
+                    <path d={svg} />
+                  </svg>
+                </div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center justify-between">
+                    <span class="font-mono text-[11px] font-medium text-slate-200 group-hover:text-white transition-colors">{name}</span>
+                    <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{tag}</span>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
         </article>
 
+        <!-- AI & Retrieval -->
         <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-          <h2 class="text-sm font-bold text-white">AI & Retrieval</h2>
-          <div class="mt-5 space-y-5">
-            {['RAG', 'LLM Ops', 'Vector Search', 'Eval Harness', 'Guardrails', 'Observability'].map((item, i) => (
-              <div class="skill-bar" data-percent={[92, 89, 86, 81, 77, 74][i]}>
-                <div class="mb-1 flex items-center justify-between text-[11px] font-mono text-slate-400"><span>{item}</span><span>{[92, 89, 86, 81, 77, 74][i]}%</span></div>
-                <div class="h-px bg-slate-800/80 overflow-hidden"><div class="skill-bar-fill h-px bg-gradient-to-r from-emerald-400 via-cyan-400 to-indigo-400" style="width:0%"></div></div>
+          <h2 class="text-xs font-semibold text-white flex items-center gap-2 mb-5">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+            AI & Retrieval
+          </h2>
+          <div class="grid gap-3">
+            {aiIcons.map(({ name, tag, color, icon: svg }) => (
+              <div class="skill-tile group flex items-center gap-3 rounded-xl border border-slate-800/40 bg-slate-950/40 p-3 transition-all duration-300 hover:border-slate-700/60 hover:bg-slate-900/60">
+                <!-- Conceptual icon -->
+                <div class="skill-icon shrink-0 w-9 h-9 rounded-lg border border-slate-700/40 bg-slate-900/60 flex items-center justify-center" style={`border-color: ${color}20;`}>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="skill-icon-svg">
+                    <path d={svg} />
+                  </svg>
+                </div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center justify-between">
+                    <span class="font-mono text-[11px] font-medium text-slate-200 group-hover:text-white transition-colors">{name}</span>
+                    <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{tag}</span>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
         </article>
       </section>
 
+      <!-- ════════════════════════════════════════
+           Certifications — credential badges
+      ════════════════════════════════════════ -->
       <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-        <p class="section-eyebrow text-indigo-300">[MODULE: CERTIFICATIONS]</p>
-        <div class="mt-6 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-          {[
-            ['Google Cloud Certified — Professional Data Engineer','GCP · BigQuery · Dataflow · AI/ML'],
-            ['Talend Data Explorer Certification','Big Data · ETL · CDC'],
-            ['CCA Spark and Hadoop Developer','PySpark · Hadoop · Big Data'],
-            ['Advanced Certificate in Blockchain — IIIT Hyderabad','DLT · Security · Enterprise Blockchain'],
-            ['Globee Award — IT World Awards®','Leadership · Innovation · Digital Transformation'],
-          ].map(([title, meta]) => (
-            <article class="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-5 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-              <h3 class="text-sm font-bold text-white">{title}</h3>
-              <p class="mt-2 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-500">{meta}</p>
+        <p class="section-eyebrow text-indigo-300 flex items-center gap-2">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="2"><path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+          CERTIFICATIONS
+        </p>
+        <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {certs.map(([title, meta, type]) => (
+            <article class="cert-card rounded-2xl border border-slate-800/70 bg-slate-950/70 p-5 shadow-[0_10px_30px_rgba(2,6,23,0.35)] transition-all duration-300 hover:border-indigo-500/30 hover:shadow-[0_0_24px_rgba(99,102,241,0.08)]">
+              <div class="flex items-start gap-3">
+                <div class="shrink-0 w-8 h-8 rounded-lg border border-slate-700/50 bg-slate-900/60 flex items-center justify-center">
+                  {type === 'google' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M8 12l2 2 4-4"/></svg>}
+                  {type === 'talend' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>}
+                  {type === 'spark' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="1.5"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>}
+                  {type === 'blockchain' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="1.5"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>}
+                  {type === 'award' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="1.5"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg>}
+                </div>
+                <div class="min-w-0">
+                  <h3 class="text-xs font-semibold text-white leading-snug">{title}</h3>
+                  <p class="mt-1.5 font-mono text-[10px] uppercase tracking-[0.15em] text-slate-500">{meta}</p>
+                </div>
+              </div>
             </article>
           ))}
         </div>
       </section>
 
+      <!-- ════════════════════════════════════════
+           Stack — animated tag grid
+      ════════════════════════════════════════ -->
       <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-        <p class="section-eyebrow text-cyan-300">[MODULE: STACK]</p>
-        <div class="mt-4 flex flex-wrap gap-2">
-          {['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python','SQL','Terraform','Cloud Run','LangGraph','Postgres'].map(item => (
-            <span class="rounded-full border border-slate-700/60 bg-slate-950/70 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-400">{item}</span>
+        <p class="section-eyebrow text-cyan-300">STACK</p>
+        <div class="mt-4 flex flex-wrap gap-2 stack-tags">
+          {stackTags.map(item => (
+            <span class="stack-tag rounded-full border border-slate-700/60 bg-slate-950/70 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-400 transition-all duration-200 hover:border-cyan-400/30 hover:text-cyan-300 hover:shadow-[0_0_12px_rgba(34,211,238,0.06)]">
+              {item}
+            </span>
           ))}
         </div>
       </section>
     </section>
   </main>
 </Layout>
+
+<style>
+  .skill-icon-svg path {
+    stroke-dasharray: 60;
+    stroke-dashoffset: 60;
+    transition: stroke-dashoffset 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .skill-tile.is-visible .skill-icon-svg path {
+    stroke-dashoffset: 0;
+  }
+  .skill-tile:hover .skill-icon-svg path {
+    stroke-dashoffset: 0;
+  }
+
+  .cert-card {
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skill-icon-svg path { stroke-dashoffset: 0; transition: none; }
+    .stack-tag { opacity: 1 !important; transform: none !important; }
+    .cert-card { opacity: 1 !important; transform: none !important; }
+  }
+</style>
 
 <script>
   import gsap from 'gsap';
@@ -76,20 +219,59 @@ import Layout from '../layouts/Layout.astro';
   const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (!prefersReduced) {
-    document.querySelectorAll('.skill-bar').forEach((bar) => {
-      const inner = bar.querySelector('div:last-child > div') as HTMLElement;
-      const pct = bar.getAttribute('data-percent');
-      if (inner && pct) {
-        const target = pct + '%';
-        ScrollTrigger.create({
-          trigger: bar,
-          start: 'top 85%',
-          once: true,
-          onEnter: () => {
-            gsap.to(inner, { width: target, duration: 1.2, ease: 'power3.out' });
-          },
-        });
-      }
+    // ── Icon path draw animation ──
+    document.querySelectorAll('.skill-tile').forEach((tile, i) => {
+      ScrollTrigger.create({
+        trigger: tile,
+        start: 'top 90%',
+        once: true,
+        onEnter: () => {
+          setTimeout(() => tile.classList.add('is-visible'), i * 40);
+        },
+      });
+    });
+
+    // ── Tile stagger reveal ──
+    gsap.from('.skill-tile', {
+      opacity: 0,
+      x: -12,
+      stagger: 0.04,
+      duration: 0.4,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: '.skill-tile',
+        start: 'top 85%',
+        toggleActions: 'play none none none',
+      },
+    });
+
+    // ── Certification card stagger ──
+    gsap.from('.cert-card', {
+      opacity: 0,
+      y: 20,
+      stagger: 0.07,
+      duration: 0.5,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: '.cert-card',
+        start: 'top 85%',
+        toggleActions: 'play none none none',
+      },
+    });
+
+    // ── Stack tag burst ──
+    gsap.from('.stack-tag', {
+      opacity: 0,
+      scale: 0.7,
+      y: 12,
+      stagger: 0.03,
+      duration: 0.4,
+      ease: 'back.out(1.7)',
+      scrollTrigger: {
+        trigger: '.stack-tags',
+        start: 'top 80%',
+        toggleActions: 'play none none none',
+      },
     });
   }
 </script>

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -1,65 +1,22 @@
 ---
 import Layout from '../layouts/Layout.astro';
 
-interface SkillIcon {
-  name: string;
-  tag: string;
-  color: string;
-  icon: string; // SVG path data
-}
-
-const platformIcons: SkillIcon[] = [
-  {
-    name: 'GCP', tag: 'Cloud Platform', color: '#22d3ee',
-    icon: 'M5 15a4 4 0 0 1 0-8 4 4 0 0 1 7.4-2A3 3 0 0 1 16 9.5a2.5 2.5 0 0 1 0 5H5Z',
-  },
-  {
-    name: 'BigQuery', tag: 'Data Warehouse', color: '#818cf8',
-    icon: 'M4 7h16M4 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2M4 7v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7M4 12h16',
-  },
-  {
-    name: 'Dataflow', tag: 'Stream Processing', color: '#34d399',
-    icon: 'M3 17l5-5 4 5 5-7 4 4',
-  },
-  {
-    name: 'Vertex AI', tag: 'Machine Learning', color: '#a78bfa',
-    icon: 'M12 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM6 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM18 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM12 20a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM7 7l5 4ZM17 7l-5 4ZM7 17l5-4ZM17 17l5-4Z',
-  },
-  {
-    name: 'Cloud Run', tag: 'Serverless', color: '#38bdf8',
-    icon: 'M8 4v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V4M8 4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2M8 4H6M16 4h2M9 14h6',
-  },
-  {
-    name: 'Terraform', tag: 'Infrastructure as Code', color: '#f59e0b',
-    icon: 'M5 20V9l7-4 7 4v11M5 20h14M5 20H3M19 20h2M12 9v4',
-  },
+const platformSkills = [
+  { name: 'GCP',         tag: 'Cloud Platform',       color: '#22d3ee', icon: 'M5 15a4 4 0 0 1 0-8 4 4 0 0 1 7.4-2A3 3 0 0 1 16 9.5a2.5 2.5 0 0 1 0 5H5Z' },
+  { name: 'BigQuery',    tag: 'Data Warehouse',       color: '#818cf8', icon: 'M4 7h16M4 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2M4 7v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7M4 12h16' },
+  { name: 'Dataflow',    tag: 'Stream Processing',    color: '#34d399', icon: 'M3 17l5-5 4 5 5-7 4 4' },
+  { name: 'Vertex AI',   tag: 'Machine Learning',     color: '#a78bfa', icon: 'M12 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM6 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM18 12a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM12 20a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM7 7l5 4ZM17 7l-5 4ZM7 17l5-4ZM17 17l5-4Z' },
+  { name: 'Cloud Run',   tag: 'Serverless',           color: '#38bdf8', icon: 'M8 4v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V4M8 4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2M8 4H6M16 4h2M9 14h6' },
+  { name: 'Terraform',   tag: 'Infrastructure as Code',color: '#f59e0b', icon: 'M5 20V9l7-4 7 4v11M5 20h14M5 20H3M19 20h2M12 9v4' },
 ];
 
-const aiIcons: SkillIcon[] = [
-  {
-    name: 'RAG', tag: 'Retrieval Augmented', color: '#34d399',
-    icon: 'M7 4h6l4 4v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2ZM14 8V4M9 13l2 2 4-4',
-  },
-  {
-    name: 'LLM Ops', tag: 'Lifecycle', color: '#818cf8',
-    icon: 'M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8ZM12 2v2M12 20v2M2 12h2M20 12h2',
-  },
-  {
-    name: 'Vector Search', tag: 'Similarity', color: '#22d3ee',
-    icon: 'M4 20L12 4l8 16M8 13l8-2M8 13l2 6M16 11l2 6',
-  },
-  {
-    name: 'Eval Harness', tag: 'Evaluation', color: '#fbbf24',
-    icon: 'M12 2a10 10 0 1 0 10 10M12 2v10l6 6M12 2a10 10 0 0 1 10 10',
-  },
-  {
-    name: 'Guardrails', tag: 'Safety', color: '#34d399',
-    icon: 'M12 2l8 4v6a8 8 0 0 1-8 8 8 8 0 0 1-8-8V6l8-4ZM9 12l2 2 4-4',
-  },
-  {
-    name: 'Observability', tag: 'Monitoring', color: '#38bdf8',
-    icon: 'M2 20h20M4 16l4-8 4 4 4-6 4 8',
-  },
+const aiSkills = [
+  { name: 'RAG',              tag: 'Retrieval Augmented', color: '#34d399', icon: 'M7 4h6l4 4v10a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2ZM14 8V4M9 13l2 2 4-4' },
+  { name: 'LLM Ops',          tag: 'Lifecycle',           color: '#818cf8', icon: 'M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8ZM12 2v2M12 20v2M2 12h2M20 12h2' },
+  { name: 'Vector Search',    tag: 'Similarity',          color: '#22d3ee', icon: 'M4 20L12 4l8 16M8 13l8-2M8 13l2 6M16 11l2 6' },
+  { name: 'Eval Harness',     tag: 'Evaluation',          color: '#fbbf24', icon: 'M12 2a10 10 0 1 0 10 10M12 2v10l6 6M12 2a10 10 0 0 1 10 10' },
+  { name: 'Guardrails',       tag: 'Safety',              color: '#34d399', icon: 'M12 2l8 4v6a8 8 0 0 1-8 8 8 8 0 0 1-8-8V6l8-4ZM9 12l2 2 4-4' },
+  { name: 'Observability',    tag: 'Monitoring',          color: '#38bdf8', icon: 'M2 20h20M4 16l4-8 4 4 4-6 4 8' },
 ];
 
 const certs = [
@@ -75,38 +32,35 @@ const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python
 
 <Layout title="Skills & Certifications — Jagadeesh Thiruveedula" navLabel="J. T.">
   <main class="min-h-screen bg-slate-950 px-4 py-20 text-slate-100 md:px-8 lg:px-12">
-    <section class="mx-auto flex w-full max-w-6xl flex-col gap-10">
+    <section class="mx-auto flex w-full max-w-6xl flex-col gap-8">
 
-      <header class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_12px_40px_rgba(2,6,23,0.45)] md:p-10">
+      <header class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_12px_40px_rgba(2,6,23,0.45)] md:p-8">
         <p class="section-eyebrow text-amber-300">SKILLS</p>
         <h1 class="text-2xl font-bold text-white md:text-3xl">Skills & Certifications</h1>
-        <p class="mt-3 max-w-3xl text-xs text-slate-400 leading-relaxed">A compact systems view of the cloud, data, AI, and automation stack behind enterprise delivery.</p>
+        <p class="mt-2 max-w-3xl text-xs text-slate-400 leading-relaxed">Cloud, data, AI, and automation stack behind enterprise delivery.</p>
       </header>
 
       <!-- ════════════════════════════════════════
            Concept tiles — visual storytelling
       ════════════════════════════════════════ -->
-      <section class="grid gap-6 md:grid-cols-2">
+      <section class="grid gap-5 md:grid-cols-2">
         <!-- Platform & Cloud -->
-        <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-          <h2 class="text-xs font-semibold text-white flex items-center gap-2 mb-5">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg>
+        <article class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+          <h2 class="text-[10px] font-semibold text-white flex items-center gap-2 mb-4 uppercase tracking-widest">
+            <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2.5"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg>
             Platform & Cloud
           </h2>
-          <div class="grid gap-3">
-            {platformIcons.map(({ name, tag, color, icon: svg }) => (
-              <div class="skill-tile group flex items-center gap-3 rounded-xl border border-slate-800/40 bg-slate-950/40 p-3 transition-all duration-300 hover:border-slate-700/60 hover:bg-slate-900/60">
-                <!-- Conceptual icon -->
-                <div class="skill-icon shrink-0 w-9 h-9 rounded-lg border border-slate-700/40 bg-slate-900/60 flex items-center justify-center" style={`border-color: ${color}20;`}>
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="skill-icon-svg">
-                    <path d={svg} />
+          <div class="flex flex-col gap-2">
+            {platformSkills.map(s => (
+              <div class="skill-tile flex items-center gap-2.5 rounded-lg border border-slate-800/30 bg-slate-950/30 px-3 py-2 transition-all duration-200 hover:bg-slate-900/60 hover:border-slate-700/50">
+                <div class="shrink-0 w-8 h-8 rounded-lg border border-slate-700/30 bg-slate-900/50 flex items-center justify-center">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={s.color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-path">
+                    <path d={s.icon} />
                   </svg>
                 </div>
-                <div class="min-w-0 flex-1">
-                  <div class="flex items-center justify-between">
-                    <span class="font-mono text-[11px] font-medium text-slate-200 group-hover:text-white transition-colors">{name}</span>
-                    <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{tag}</span>
-                  </div>
+                <div class="flex-1 flex items-center justify-between min-w-0">
+                  <span class="font-mono text-xs font-medium text-slate-200">{s.name}</span>
+                  <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{s.tag}</span>
                 </div>
               </div>
             ))}
@@ -114,25 +68,22 @@ const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python
         </article>
 
         <!-- AI & Retrieval -->
-        <article class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-          <h2 class="text-xs font-semibold text-white flex items-center gap-2 mb-5">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+        <article class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+          <h2 class="text-[10px] font-semibold text-white flex items-center gap-2 mb-4 uppercase tracking-widest">
+            <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
             AI & Retrieval
           </h2>
-          <div class="grid gap-3">
-            {aiIcons.map(({ name, tag, color, icon: svg }) => (
-              <div class="skill-tile group flex items-center gap-3 rounded-xl border border-slate-800/40 bg-slate-950/40 p-3 transition-all duration-300 hover:border-slate-700/60 hover:bg-slate-900/60">
-                <!-- Conceptual icon -->
-                <div class="skill-icon shrink-0 w-9 h-9 rounded-lg border border-slate-700/40 bg-slate-900/60 flex items-center justify-center" style={`border-color: ${color}20;`}>
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="skill-icon-svg">
-                    <path d={svg} />
+          <div class="flex flex-col gap-2">
+            {aiSkills.map(s => (
+              <div class="skill-tile flex items-center gap-2.5 rounded-lg border border-slate-800/30 bg-slate-950/30 px-3 py-2 transition-all duration-200 hover:bg-slate-900/60 hover:border-slate-700/50">
+                <div class="shrink-0 w-8 h-8 rounded-lg border border-slate-700/30 bg-slate-900/50 flex items-center justify-center">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={s.color} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-path">
+                    <path d={s.icon} />
                   </svg>
                 </div>
-                <div class="min-w-0 flex-1">
-                  <div class="flex items-center justify-between">
-                    <span class="font-mono text-[11px] font-medium text-slate-200 group-hover:text-white transition-colors">{name}</span>
-                    <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{tag}</span>
-                  </div>
+                <div class="flex-1 flex items-center justify-between min-w-0">
+                  <span class="font-mono text-xs font-medium text-slate-200">{s.name}</span>
+                  <span class="font-mono text-[9px] text-slate-600 uppercase tracking-wider">{s.tag}</span>
                 </div>
               </div>
             ))}
@@ -141,27 +92,24 @@ const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python
       </section>
 
       <!-- ════════════════════════════════════════
-           Certifications — credential badges
+           Certifications
       ════════════════════════════════════════ -->
-      <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
-        <p class="section-eyebrow text-indigo-300 flex items-center gap-2">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="2"><path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
-          CERTIFICATIONS
-        </p>
-        <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <section class="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+        <p class="section-eyebrow text-indigo-300">CERTIFICATIONS</p>
+        <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {certs.map(([title, meta, type]) => (
-            <article class="cert-card rounded-2xl border border-slate-800/70 bg-slate-950/70 p-5 shadow-[0_10px_30px_rgba(2,6,23,0.35)] transition-all duration-300 hover:border-indigo-500/30 hover:shadow-[0_0_24px_rgba(99,102,241,0.08)]">
-              <div class="flex items-start gap-3">
-                <div class="shrink-0 w-8 h-8 rounded-lg border border-slate-700/50 bg-slate-900/60 flex items-center justify-center">
-                  {type === 'google' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M8 12l2 2 4-4"/></svg>}
-                  {type === 'talend' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="1.5"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>}
-                  {type === 'spark' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="1.5"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>}
-                  {type === 'blockchain' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="1.5"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>}
-                  {type === 'award' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="1.5"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg>}
+            <article class="cert-card rounded-xl border border-slate-800/60 bg-slate-950/60 p-4 transition-all duration-200 hover:border-indigo-500/25 hover:shadow-[0_0_20px_rgba(99,102,241,0.06)]">
+              <div class="flex items-start gap-2.5">
+                <div class="shrink-0 w-7 h-7 rounded-lg border border-slate-700/40 bg-slate-900/50 flex items-center justify-center">
+                  {type === 'google' && <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#818cf8" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M8 12l2 2 4-4"/></svg>}
+                  {type === 'talend' && <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>}
+                  {type === 'spark' && <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>}
+                  {type === 'blockchain' && <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>}
+                  {type === 'award' && <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg>}
                 </div>
                 <div class="min-w-0">
-                  <h3 class="text-xs font-semibold text-white leading-snug">{title}</h3>
-                  <p class="mt-1.5 font-mono text-[10px] uppercase tracking-[0.15em] text-slate-500">{meta}</p>
+                  <h3 class="text-xs font-medium text-white leading-snug">{title}</h3>
+                  <p class="mt-1 font-mono text-[9px] uppercase tracking-[0.15em] text-slate-500">{meta}</p>
                 </div>
               </div>
             </article>
@@ -170,13 +118,13 @@ const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python
       </section>
 
       <!-- ════════════════════════════════════════
-           Stack — animated tag grid
+           Stack tags
       ════════════════════════════════════════ -->
-      <section class="rounded-3xl border border-slate-800/70 bg-slate-900/40 p-6 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
+      <section class="rounded-2xl border border-slate-800/70 bg-slate-900/40 px-5 py-4 shadow-[0_10px_30px_rgba(2,6,23,0.35)]">
         <p class="section-eyebrow text-cyan-300">STACK</p>
-        <div class="mt-4 flex flex-wrap gap-2 stack-tags">
+        <div class="mt-3 flex flex-wrap gap-1.5">
           {stackTags.map(item => (
-            <span class="stack-tag rounded-full border border-slate-700/60 bg-slate-950/70 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.25em] text-slate-400 transition-all duration-200 hover:border-cyan-400/30 hover:text-cyan-300 hover:shadow-[0_0_12px_rgba(34,211,238,0.06)]">
+            <span class="stack-tag rounded-full border border-slate-700/50 bg-slate-950/60 px-2.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.2em] text-slate-400 transition-colors duration-200 hover:border-cyan-400/20 hover:text-cyan-300">
               {item}
             </span>
           ))}
@@ -187,91 +135,68 @@ const stackTags = ['GCP','BigQuery','Dataflow','Vertex AI','GenAI','RAG','Python
 </Layout>
 
 <style>
-  .skill-icon-svg path {
+  .icon-path path {
     stroke-dasharray: 60;
     stroke-dashoffset: 60;
     transition: stroke-dashoffset 0.8s cubic-bezier(0.22, 1, 0.36, 1);
   }
-  .skill-tile.is-visible .skill-icon-svg path {
+  .is-visible .icon-path path,
+  .skill-tile:hover .icon-path path {
     stroke-dashoffset: 0;
   }
-  .skill-tile:hover .skill-icon-svg path {
-    stroke-dashoffset: 0;
-  }
-
-  .cert-card {
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .skill-icon-svg path { stroke-dashoffset: 0; transition: none; }
-    .stack-tag { opacity: 1 !important; transform: none !important; }
-    .cert-card { opacity: 1 !important; transform: none !important; }
+    .icon-path path { stroke-dashoffset: 0; transition: none; }
   }
 </style>
 
 <script>
   import gsap from 'gsap';
   import { ScrollTrigger } from 'gsap/ScrollTrigger';
-
   gsap.registerPlugin(ScrollTrigger);
 
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  if (!prefersReduced) {
-    // ── Icon path draw animation ──
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // ── Icon path draw on scroll ──
     document.querySelectorAll('.skill-tile').forEach((tile, i) => {
       ScrollTrigger.create({
         trigger: tile,
-        start: 'top 90%',
+        start: 'top 92%',
         once: true,
-        onEnter: () => {
-          setTimeout(() => tile.classList.add('is-visible'), i * 40);
-        },
+        onEnter: () => setTimeout(() => tile.classList.add('is-visible'), i * 50),
       });
     });
 
-    // ── Tile stagger reveal ──
+    // ── Tile entrance (translate, no opacity) ──
     gsap.from('.skill-tile', {
-      opacity: 0,
-      x: -12,
-      stagger: 0.04,
-      duration: 0.4,
-      ease: 'power3.out',
+      x: -10,
+      opacity: 0.6,
+      stagger: 0.035,
+      duration: 0.45,
+      ease: 'power2.out',
       scrollTrigger: {
         trigger: '.skill-tile',
-        start: 'top 85%',
+        start: 'top 88%',
         toggleActions: 'play none none none',
       },
     });
 
-    // ── Certification card stagger ──
+    // ── Cert cards ──
     gsap.from('.cert-card', {
       opacity: 0,
-      y: 20,
-      stagger: 0.07,
-      duration: 0.5,
-      ease: 'power3.out',
-      scrollTrigger: {
-        trigger: '.cert-card',
-        start: 'top 85%',
-        toggleActions: 'play none none none',
-      },
+      y: 12,
+      stagger: 0.06,
+      duration: 0.4,
+      ease: 'power2.out',
+      scrollTrigger: { trigger: '.cert-card', start: 'top 88%', toggleActions: 'play none none none' },
     });
 
-    // ── Stack tag burst ──
+    // ── Stack tags ──
     gsap.from('.stack-tag', {
       opacity: 0,
       scale: 0.7,
-      y: 12,
-      stagger: 0.03,
-      duration: 0.4,
+      stagger: 0.025,
+      duration: 0.3,
       ease: 'back.out(1.7)',
-      scrollTrigger: {
-        trigger: '.stack-tags',
-        start: 'top 80%',
-        toggleActions: 'play none none none',
-      },
+      scrollTrigger: { trigger: '.stack-tag', start: 'top 85%', toggleActions: 'play none none none' },
     });
   }
 </script>


### PR DESCRIPTION
## Changes

Global typography reduction across all pages (lower weights, smaller sizes, better line-height).

**Visual additions:**
- HeroNodeGraph enhanced with DATA/RAG/AGENTS/GUARD labels + breathing node animation
- Tension SVG gets 'Demo → Production' labels
- Pipeline connector progress line
- Capabilities inline SVG icons (chat/database/nodes)
- Deployments micro graph bars behind metrics
- About: Data→Cloud→AI timeline
- Experience: timeline rail with animated dots
- Contact: session card with 01→02→03 step reveal

**Motion refinement:**
- Cursor parallax capped at 30px (was 42px)
- Removed elastic/bouncy easing, replaced with power3.out
- Reduced y-offsets and stacking depth

**Nav enhancement:**
- Label shuffles through name variants while scrolling (Jagadeesh → Thiruveedula → J.T. → Jagadeesh T. → full name)
- Inner pages show static name variants