### PR TITLE
feat(hero+about+nav): cinematic reveal system + About rewrite + command-bar nav

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
     "Agentic Workflows",
     "Senior Data Engineer",
     "DFW",
-    "Corinth Texas",
+    "Dallas Texas",
     "LangChain",
     "Vector Search",
   ],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ function SmoothScroll() {
         <AmbientOrbs />
         <SoundControl />
         <Navbar />
-        <main id="main" tabIndex={-1} className="relative z-10 min-h-screen pt-14">
+        <main id="main" tabIndex={-1} className="relative z-10 min-h-screen pt-24 md:pt-24">
           {/* UPGRADE: PageReveal wrapper drives Hero entrance sequence */}
           <PageReveal>
             <Hero />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -18,14 +18,27 @@ const navLinks = [
 
 const sectionIds = navLinks.map((l) => l.href.slice(1));
 
+const TOP_EDGE_PX = 48;
+const HIDE_BAR_THRESHOLD = 80;
+const HIDE_IDENTITY_THRESHOLD = 200;
+const TRANSITION = "transform 320ms cubic-bezier(0.22, 1, 0.36, 1), opacity 280ms ease, background-color 200ms ease, box-shadow 200ms ease";
+
 export default function Navbar() {
   const active = useScrollSection(sectionIds);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [scrollY, setScrollY] = useState(0);
+  const [scrollDirection, setScrollDirection] = useState<"up" | "down">("up");
+  const [isNearTopEdge, setIsNearTopEdge] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
   const navRef = useRef<HTMLElement>(null);
   const logoRef = useRef<HTMLSpanElement>(null);
   const navItemsRef = useRef<HTMLDivElement>(null);
   const identityRef = useRef<HTMLDivElement>(null);
   const nameRevealRef = useRef<HTMLSpanElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const wasVisibleRef = useRef(true);
   const { play } = useSound();
 
   useEffect(() => {
@@ -50,38 +63,96 @@ export default function Navbar() {
   }, [mobileOpen, play]);
 
   useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    let frame = 0;
+    let lastY = window.scrollY;
+
+    const tick = () => {
+      frame = 0;
+      const y = window.scrollY;
+      const dir: "up" | "down" = y > lastY ? "down" : y < lastY ? "up" : scrollDirection;
+      lastY = y;
+      if (y !== scrollY) setScrollY(y);
+      if (dir !== scrollDirection) setScrollDirection(dir);
+    };
+
+    const onScroll = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(tick);
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [scrollY, scrollDirection]);
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      setIsNearTopEdge(e.clientY <= TOP_EDGE_PX);
+    };
+    window.addEventListener("pointermove", onMove, { passive: true });
+    return () => window.removeEventListener("pointermove", onMove);
+  }, []);
+
+  const isBarVisible = scrollY <= HIDE_BAR_THRESHOLD || scrollDirection === "up" || isNearTopEdge || mobileOpen;
+  const isIdentityVisible = scrollY <= HIDE_IDENTITY_THRESHOLD;
+  const isCompact = scrollY > HIDE_BAR_THRESHOLD;
+  const barParallaxY = Math.min(scrollY * 0.015, 3);
+  const identityParallaxY = Math.min(scrollY * 0.05, 8);
+
+  useEffect(() => {
+    if (reducedMotion) return;
+    if (wasVisibleRef.current === isBarVisible) return;
+    wasVisibleRef.current = isBarVisible;
+    if (!isBarVisible) return;
+    const tween = gsap.fromTo(
+      barRef.current,
+      { boxShadow: "0 0 0 0 color-mix(in srgb, var(--color-accent) 0%, transparent)" },
+      {
+        boxShadow: "0 0 18px 0 color-mix(in srgb, var(--color-accent) 45%, transparent)",
+        duration: 0.5,
+        ease: "power2.out",
+        yoyo: true,
+        repeat: 1,
+      }
+    );
+    return () => { tween.kill(); };
+  }, [isBarVisible, reducedMotion]);
+
+  useEffect(() => {
     const nav = navRef.current;
     if (!nav) return;
 
-    const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const intensity = Math.max(75, 98 - scrollY / 15);
-      const glowOpacity = Math.max(0.05, 0.35 - scrollY / 500);
-      nav.style.boxShadow = `0 1px 0 color-mix(in srgb, var(--color-accent) ${glowOpacity * 100}%, transparent), 0 0 ${10 + glowOpacity * 20}px color-mix(in srgb, var(--color-accent) ${glowOpacity * 60}%, transparent)`;
-      nav.style.backgroundColor = `color-mix(in srgb, var(--color-bg) ${intensity}%, transparent)`;
-    };
-
-    handleScroll();
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+    const intensity = Math.max(75, 98 - scrollY / 15);
+    const glowOpacity = Math.max(0.08, 0.35 - scrollY / 500);
+    nav.style.backgroundColor = `color-mix(in srgb, var(--color-bg) ${intensity}%, transparent)`;
+    nav.style.boxShadow = hovered
+      ? `0 1px 0 color-mix(in srgb, var(--color-accent) ${Math.min(glowOpacity * 2.2, 0.85) * 100}%, transparent), 0 0 ${14 + glowOpacity * 28}px color-mix(in srgb, var(--color-accent) ${Math.min(glowOpacity * 1.8, 0.7) * 100}%, transparent), var(--neon-shadow-sm)`
+      : `0 1px 0 color-mix(in srgb, var(--color-accent) ${glowOpacity * 100}%, transparent), 0 0 ${10 + glowOpacity * 20}px color-mix(in srgb, var(--color-accent) ${glowOpacity * 60}%, transparent)`;
+  }, [scrollY, hovered]);
 
   useEffect(() => {
     const el = nameRevealRef.current;
     if (!el) return;
-
-    const isReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-    if (isReducedMotion) {
+    if (reducedMotion) {
       gsap.set(el, { width: "auto" });
       return;
     }
-
     const ctx = gsap.context(() => {
       gsap.set(el, { width: "auto" });
     });
     return () => ctx.revert();
-  }, []);
+  }, [reducedMotion]);
 
   useEffect(() => {
     if (!navItemsRef.current) return;
@@ -100,7 +171,7 @@ export default function Navbar() {
 
   useEffect(() => {
     if (!logoRef.current) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (reducedMotion) return;
     const tl = gsap.to(logoRef.current, {
       textShadow: "0 0 12px var(--color-accent), 0 0 24px var(--color-accent), 0 0 36px var(--color-accent), 0 0 48px var(--color-accent)",
       duration: 2,
@@ -109,7 +180,7 @@ export default function Navbar() {
       ease: "sine.inOut",
     });
     return () => { tl.kill(); };
-  }, []);
+  }, [reducedMotion]);
 
   const handleNavClick = (href: string) => {
     play("click");
@@ -118,24 +189,52 @@ export default function Navbar() {
     el?.scrollIntoView({ behavior: "smooth" });
   };
 
+  const navStyle: React.CSSProperties = {
+    transform: isBarVisible ? `translateY(${barParallaxY}px)` : "translateY(-110%)",
+    opacity: isBarVisible ? 1 : 0,
+    pointerEvents: isBarVisible ? "auto" : "none",
+    transition: reducedMotion ? "none" : TRANSITION,
+  };
+
   return (
     <>
       <nav
         ref={navRef}
-        className="fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-xl transition-shadow duration-300"
-        style={{ borderColor: "var(--color-glass-border)", backgroundColor: "color-mix(in srgb, var(--color-bg) 80%, transparent)", boxShadow: "0 1px 0 color-mix(in srgb, var(--color-accent) 35%, transparent), var(--neon-shadow-sm)" }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-xl"
+        style={{
+          ...navStyle,
+          borderColor: "var(--color-glass-border)",
+          backgroundColor: "color-mix(in srgb, var(--color-bg) 80%, transparent)",
+          boxShadow: "0 1px 0 color-mix(in srgb, var(--color-accent) 35%, transparent), var(--neon-shadow-sm)",
+        }}
+        aria-label="Primary"
       >
-        <div className="container mx-auto px-4 md:px-6">
-          <div className="flex items-center justify-between h-14">
+        <div
+          ref={barRef}
+          className="container mx-auto px-4 md:px-6"
+        >
+          <div
+            className="flex items-center justify-between"
+            style={{ height: isCompact ? 40 : 56, transition: reducedMotion ? "none" : "height 240ms cubic-bezier(0.22, 1, 0.36, 1)" }}
+          >
             <a
               href="#hero"
               onClick={(e) => { e.preventDefault(); handleNavClick("#hero"); }}
               className="flex items-center gap-2 group"
               aria-label="Home"
             >
-              <span ref={logoRef} className="font-mono text-base font-bold transition-colors flex items-center" style={{ color: "var(--color-accent)", textShadow: "0 0 7px var(--color-accent), 0 0 10px var(--color-accent), 0 0 21px var(--color-accent)" }}
+              <span
+                ref={logoRef}
+                className="font-mono text-base font-bold transition-colors flex items-center"
+                style={{
+                  color: "var(--color-accent)",
+                  textShadow: "0 0 7px var(--color-accent), 0 0 10px var(--color-accent), 0 0 21px var(--color-accent)",
+                }}
                 onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = "color-mix(in srgb, var(--color-accent) 70%, white)"; }}
-                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-accent)"; }}>
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = "var(--color-accent)"; }}
+              >
                 <span>JT</span>
                 <span className="inline-block w-[2px] h-[1em] ml-1 align-text-bottom animate-pulse" style={{ backgroundColor: "var(--color-accent)" }} />
                 <span
@@ -159,11 +258,7 @@ export default function Navbar() {
                 <button
                   key={link.href}
                   onClick={() => handleNavClick(link.href)}
-                  className={`nav-item-btn relative px-3 py-1.5 text-xs font-semibold rounded-md transition-colors duration-200 ${
-                    active === link.href.slice(1)
-                      ? ""
-                      : ""
-                  }`}
+                  className="nav-item-btn relative px-3 py-1.5 text-xs font-semibold rounded-md transition-colors duration-200"
                   style={{
                     color: active === link.href.slice(1) ? "var(--color-accent)" : "var(--color-text-secondary)",
                     textShadow: active === link.href.slice(1) ? "0 0 8px var(--color-accent)" : "none",
@@ -217,14 +312,51 @@ export default function Navbar() {
         </div>
 
         <div
+          className="nav-underline absolute left-0 right-0 pointer-events-none"
+          style={{
+            bottom: 0,
+            height: 1,
+            background: "linear-gradient(90deg, transparent 0%, color-mix(in srgb, var(--color-accent) 65%, transparent) 50%, transparent 100%)",
+            boxShadow: hovered
+              ? "0 0 10px color-mix(in srgb, var(--color-accent) 70%, transparent), 0 0 18px color-mix(in srgb, var(--color-accent) 35%, transparent)"
+              : "0 0 6px color-mix(in srgb, var(--color-accent) 35%, transparent)",
+            opacity: hovered ? 1 : 0.7,
+            transition: reducedMotion ? "none" : "opacity 240ms ease, box-shadow 240ms ease",
+          }}
+        />
+
+        <div
+          className="nav-light-bleed absolute left-0 right-0 pointer-events-none"
+          style={{
+            top: "100%",
+            height: 24,
+            background: "linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 12%, transparent) 0%, transparent 100%)",
+            opacity: isBarVisible ? 1 : 0,
+            transition: reducedMotion ? "none" : "opacity 320ms ease",
+          }}
+        />
+
+        <div
           ref={identityRef}
           className="overflow-hidden border-t pointer-events-none"
-          style={{ borderColor: "var(--color-glass-border)", opacity: 1 }}
+          style={{
+            borderColor: "var(--color-glass-border)",
+            maxHeight: isIdentityVisible ? 40 : 0,
+            opacity: isIdentityVisible ? 1 : 0,
+            transform: `translateY(-${identityParallaxY}px)`,
+            transition: reducedMotion ? "none" : "max-height 320ms cubic-bezier(0.22, 1, 0.36, 1), opacity 240ms ease, transform 200ms ease",
+          }}
+          aria-hidden={!isIdentityVisible}
         >
           <div className="container mx-auto px-4 md:px-6 py-2 flex items-center justify-center gap-3">
             <span
               className="font-mono text-[11px] md:text-xs font-semibold tracking-tight whitespace-nowrap"
-              style={{ color: "var(--color-text-primary)", textShadow: "0 0 8px var(--color-accent-muted)" }}
+              style={{
+                color: "var(--color-text-primary)",
+                textShadow: "0 0 8px var(--color-accent-muted)",
+                opacity: isCompact ? 0.6 : 1,
+                transition: reducedMotion ? "none" : "opacity 240ms ease",
+              }}
             >
               Jagadeesh Thiruveedula
             </span>
@@ -268,7 +400,7 @@ export default function Navbar() {
               <button
                 key={link.href}
                 onClick={() => handleNavClick(link.href)}
-                className={`text-2xl font-semibold transition-colors`}
+                className="text-2xl font-semibold transition-colors"
                 style={{ color: active === link.href.slice(1) ? "var(--color-accent)" : "var(--color-text-primary)" }}
                 onMouseEnter={(e) => { if (active !== link.href.slice(1)) (e.currentTarget as HTMLElement).style.color = "var(--color-accent)"; }}
                 onMouseLeave={(e) => { if (active !== link.href.slice(1)) (e.currentTarget as HTMLElement).style.color = "var(--color-text-primary)"; }}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -97,11 +97,24 @@ export default function Navbar() {
   }, [scrollY, scrollDirection]);
 
   useEffect(() => {
+    // UPGRADE: rAF-throttle pointermove so top-edge detection doesn't fire on every event
+    let frame = 0;
+    let lastY = -1;
+    const tick = () => {
+      frame = 0;
+      if (lastY === -1) return;
+      setIsNearTopEdge(lastY <= TOP_EDGE_PX);
+    };
     const onMove = (e: PointerEvent) => {
-      setIsNearTopEdge(e.clientY <= TOP_EDGE_PX);
+      lastY = e.clientY;
+      if (frame) return;
+      frame = requestAnimationFrame(tick);
     };
     window.addEventListener("pointermove", onMove, { passive: true });
-    return () => window.removeEventListener("pointermove", onMove);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      if (frame) cancelAnimationFrame(frame);
+    };
   }, []);
 
   const isBarVisible = scrollY <= HIDE_BAR_THRESHOLD || scrollDirection === "up" || isNearTopEdge || mobileOpen;

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -9,6 +9,21 @@ import { useSound } from "@/hooks/useSound";
 
 gsap.registerPlugin(ScrollTrigger);
 
+interface Stat {
+  // UPGRADE: numeric=null skips CountUp (used for the "GCP" static label card)
+  value: number | null;
+  prefix: string;
+  suffix: string;
+  label: string;
+}
+
+const STATS: Stat[] = [
+  { value: 6, prefix: "", suffix: "+", label: "Production GenAI" },
+  { value: 12, prefix: "", suffix: "M+", label: "RAG Pipelines" },
+  { value: null, prefix: "GCP", suffix: "", label: "Data Platforms" },
+  { value: 60, prefix: "", suffix: "%", label: "Latency Cut" },
+];
+
 const ARCH_NODES = [
   { id: "sources", label: "Data Sources", x: 50, y: 30 },
   { id: "ingestion", label: "Ingestion", x: 160, y: 30 },
@@ -27,102 +42,241 @@ const CONNECTIONS = [
   { from: "bigquery", to: "insights" },
 ];
 
+// UPGRADE: visual order of node reveal pulse (left → right pipeline flow)
+const REVEAL_ORDER = ["sources", "ingestion", "bigquery", "transform", "aiml", "insights"];
+
+const SCRAMBLE_CHARS = "!<>-_\\/[]{}—=+*^?#ABCDEFGHIJKMNOPQRSTUVWXYZ0123456789";
+
+// UPGRADE: ScrambleText-style effect driven by rAF — used after CountUp to settle the label
+function scrambleTo(el: HTMLElement, final: string, duration = 0.6): void {
+  if (typeof window === "undefined") return;
+  const start = performance.now();
+  const len = final.length;
+  function frame(now: number) {
+    const elapsed = now - start;
+    const t = Math.min(elapsed / (duration * 1000), 1);
+    let out = "";
+    for (let i = 0; i < len; i++) {
+      if (final[i] === " ") {
+        out += " ";
+        continue;
+      }
+      // UPGRADE: each char settles at a staggered time (0.3 .. 1.0) for a left-to-right reveal
+      const settleAt = 0.3 + (i / Math.max(len - 1, 1)) * 0.7;
+      if (t < settleAt) {
+        out += SCRAMBLE_CHARS[Math.floor(Math.random() * SCRAMBLE_CHARS.length)];
+      } else {
+        out += final[i];
+      }
+    }
+    el.textContent = out;
+    if (t < 1) requestAnimationFrame(frame);
+    else el.textContent = final;
+  }
+  requestAnimationFrame(frame);
+}
+
 export default function About() {
   const sectionRef = useRef<HTMLElement>(null);
   const { normalizedX, normalizedY } = useMousePosition();
   const { play } = useSound();
   const svgRef = useRef<SVGSVGElement>(null);
-  const bioTextRef = useRef<HTMLDivElement>(null);
+  // UPGRADE: typed refs for the per-card number div, label div, arc path, and packet circle
+  const numRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const labelRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const connRefs = useRef<Array<SVGPathElement | null>>([]);
+  const packetRefs = useRef<Array<SVGCircleElement | null>>([]);
 
   useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (typeof window === "undefined") return;
+    const section = sectionRef.current;
+    if (!section) return;
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (reduced) {
+      // UPGRADE: reduced-motion path — render final state synchronously, no motion
+      STATS.forEach((stat, i) => {
+        const numEl = numRefs.current[i];
+        if (numEl) {
+          const finalText = stat.value === null
+            ? stat.prefix
+            : `${stat.prefix}${stat.value}${stat.suffix}`;
+          numEl.textContent = finalText;
+        }
+        const labelEl = labelRefs.current[i];
+        if (labelEl) labelEl.textContent = stat.label;
+      });
+      connRefs.current.forEach((p) => {
+        if (p) {
+          p.style.strokeDasharray = "none";
+          p.style.strokeDashoffset = "0";
+        }
+      });
+      packetRefs.current.forEach((p) => {
+        if (p) p.setAttribute("opacity", "0");
+      });
+      return;
+    }
+
+    // UPGRADE: tweens spawned inside masterTl.call callbacks are not auto-collected by
+    // gsap.context(), so we track them locally and kill on cleanup.
+    const localTweens: gsap.core.Tween[] = [];
 
     const ctx = gsap.context(() => {
-      gsap.from(".about-eyebrow", {
-        opacity: 0,
-        y: 20,
-        duration: 0.6,
-        ease: "power3.out",
+      const masterTl = gsap.timeline({
         scrollTrigger: {
-          trigger: "#about",
+          trigger: section,
           start: "top 75%",
+          once: true,
           onEnter: () => play("shimmer"),
         },
       });
 
-      const charSpans = document.querySelectorAll(".bio-char");
-      gsap.from(charSpans, {
+      // Stage 0 — section content fades in
+      masterTl.from(".about-eyebrow", {
+        opacity: 0,
+        y: 20,
+        duration: 0.6,
+        ease: "power3.out",
+      }, 0);
+      masterTl.from(".bio-char", {
         opacity: 0,
         duration: 0.04,
         stagger: 0.008,
         ease: "none",
-        scrollTrigger: {
-          trigger: "#about",
-          start: "top 70%",
-        },
-      });
-
-      gsap.from(".arch-node", {
-        scale: 0,
-        opacity: 0,
-        transformOrigin: "center",
-        stagger: 0.08,
-        duration: 0.7,
-        ease: "back.out(1.7)",
-        scrollTrigger: {
-          trigger: ".arch-diagram",
-          start: "top 80%",
-        },
-      });
-
-      const connEls = document.querySelectorAll<SVGPathElement>(".arch-conn");
-      connEls.forEach((el) => {
-        const len = el.getTotalLength();
-        el.style.strokeDasharray = `${len}`;
-        el.style.strokeDashoffset = `${len}`;
-      });
-      gsap.to(".arch-conn", {
-        strokeDashoffset: 0,
-        duration: 1.5,
-        stagger: 0.15,
-        ease: "power2.inOut",
-        scrollTrigger: {
-          trigger: ".arch-diagram",
-          start: "top 75%",
-        },
-      });
-
-      gsap.from(".photo-frame", {
-        opacity: 0,
-        scale: 0.8,
-        duration: 0.8,
-        ease: "power3.out",
-        scrollTrigger: {
-          trigger: ".photo-frame",
-          start: "top 85%",
-        },
-      });
-
-      gsap.from(".bg-flow-line", {
+      }, 0.1);
+      masterTl.from(".bg-flow-line", {
         x: -60,
         opacity: 0,
         stagger: 0.06,
         duration: 1,
         ease: "power2.out",
-        scrollTrigger: {
-          trigger: "#about",
-          start: "top 80%",
-        },
+      }, 0.2);
+
+      // Stage 1 — metric cards rise + fade in
+      masterTl.add("cards", 0.3);
+      masterTl.from(".about-stat", {
+        opacity: 0,
+        y: 24,
+        duration: 0.6,
+        ease: "power3.out",
+        stagger: 0.1,
+      }, "cards");
+
+      // Stage 2 — CountUp on the numeric stat values
+      masterTl.add("countup", "cards+=0.3");
+      STATS.forEach((stat, i) => {
+        const numEl = numRefs.current[i];
+        const labelEl = labelRefs.current[i];
+        if (!numEl || !labelEl) return;
+        if (stat.value === null) {
+          // UPGRADE: "GCP" — no CountUp, render final immediately
+          numEl.textContent = stat.prefix;
+          return;
+        }
+        const target = stat.value;
+        const obj = { v: 0 };
+        masterTl.to(obj, {
+          v: target,
+          duration: 1.5,
+          ease: "power2.out",
+          onUpdate: () => {
+            numEl.textContent = `${stat.prefix}${Math.floor(obj.v)}${stat.suffix}`;
+          },
+          onComplete: () => {
+            numEl.textContent = `${stat.prefix}${target}${stat.suffix}`;
+            // UPGRADE: post-CountUp — settle the label with a brief scramble
+            scrambleTo(labelEl, stat.label, 0.6);
+          },
+        }, "countup");
       });
-    }, sectionRef);
 
-    return () => ctx.revert();
-  }, []);
+      // Stage 3 — arch connections draw in via strokeDashoffset
+      masterTl.add("conns", "countup+=0.2");
+      connRefs.current.forEach((p) => {
+        if (!p) return;
+        const len = p.getTotalLength();
+        p.style.strokeDasharray = `${len}`;
+        p.style.strokeDashoffset = `${len}`;
+      });
+      masterTl.to(".arch-conn", {
+        strokeDashoffset: 0,
+        duration: 1.2,
+        stagger: 0.12,
+        ease: "power2.inOut",
+      }, "conns");
 
+      // Stage 4 — node pulse reveal L→R (sources → ingestion → bigquery → transform → aiml → insights)
+      masterTl.add("nodes", "conns+=0.4");
+      REVEAL_ORDER.forEach((id, i) => {
+        const node = section.querySelector<SVGGElement>(`.arch-node[data-id="${id}"]`);
+        if (!node) return;
+        masterTl.to(node, {
+          scale: 1.18,
+          duration: 0.4,
+          ease: "power2.out",
+        }, `nodes+=${i * 0.18}`);
+        masterTl.to(node, {
+          scale: 1,
+          duration: 0.5,
+          ease: "power2.in",
+        }, `nodes+=${i * 0.18 + 0.4}`);
+      });
+
+      // Stage 5 — start the looping data-packet motion along each arc
+      masterTl.call(() => {
+        packetRefs.current.forEach((p) => {
+          if (p) p.setAttribute("opacity", "0.9");
+        });
+        connRefs.current.forEach((path, i) => {
+          const packet = packetRefs.current[i];
+          if (!path || !packet) return;
+          const len = path.getTotalLength();
+          const obj = { t: 0 };
+          // UPGRADE: per-arc rAF-equivalent tween — staggered durations + delays for organic flow
+          const tween = gsap.to(obj, {
+            t: 1,
+            duration: 2.5 + (i * 0.35),
+            repeat: -1,
+            ease: "none",
+            delay: i * 0.4,
+            onUpdate: () => {
+              const pt = path.getPointAtLength(obj.t * len);
+              packet.setAttribute("cx", String(pt.x));
+              packet.setAttribute("cy", String(pt.y));
+            },
+          });
+          localTweens.push(tween);
+        });
+      }, [], "nodes+=1.0");
+
+      // Stage 6 — subtle infinite breathing glow on the final "Insights" node
+      masterTl.call(() => {
+        const insights = section.querySelector<SVGGElement>('.arch-node[data-id="insights"]');
+        if (!insights) return;
+        const tween = gsap.to(insights, {
+          scale: 1.05,
+          duration: 2.5,
+          repeat: -1,
+          yoyo: true,
+          ease: "sine.inOut",
+        });
+        localTweens.push(tween);
+      }, [], "nodes+=1.5");
+    }, section);
+
+    return () => {
+      ctx.revert();
+      // UPGRADE: kill any infinite tweens that escaped the gsap.context (packets + insights)
+      localTweens.forEach((t) => t.kill());
+      localTweens.length = 0;
+    };
+  }, [play]);
+
+  // UPGRADE: mouse-based tooltip listener preserved (independent of motion paths)
   useEffect(() => {
     const listener = (e: MouseEvent) => {
       if (!svgRef.current) return;
-      const rect = svgRef.current.getBoundingClientRect();
       const tooltips = svgRef.current.querySelectorAll(".node-tooltip");
       tooltips.forEach((tt) => {
         const node = tt.closest("g");
@@ -191,7 +345,6 @@ export default function About() {
               GCP Data Architect.
             </h2>
             <div
-              ref={bioTextRef}
               className="space-y-3 text-sm leading-relaxed font-light"
               style={{ color: "var(--color-text-secondary)" }}
             >
@@ -203,12 +356,7 @@ export default function About() {
         </div>
 
         <div className="about-highlights mt-10 grid grid-cols-2 md:grid-cols-4 gap-3 max-w-4xl">
-          {[
-            { label: "Production GenAI", value: "6+", color: "var(--color-accent)" },
-            { label: "RAG Pipelines", value: "12M+", color: "var(--color-accent-secondary)" },
-            { label: "Data Platforms", value: "GCP", color: "var(--color-accent-tertiary)" },
-            { label: "Latency Cut", value: "60%", color: "var(--color-accent)" },
-          ].map((stat, i) => (
+          {STATS.map((stat, i) => (
             <div
               key={stat.label}
               className="about-stat rounded-xl border p-4 relative overflow-hidden"
@@ -220,16 +368,23 @@ export default function About() {
               <div
                 className="absolute inset-0 pointer-events-none"
                 style={{
-                  background: `linear-gradient(135deg, ${stat.color}08, transparent)`,
+                  background: `linear-gradient(135deg, var(--color-accent) 8, transparent)`,
                 }}
               />
               <div
+                ref={(el) => { numRefs.current[i] = el; }}
                 className="text-2xl md:text-3xl font-black font-mono relative z-10"
-                style={{ color: stat.color }}
+                style={{
+                  color: stat.value === null
+                    ? "var(--color-accent-tertiary)"
+                    : "var(--color-accent)",
+                }}
               >
-                {stat.value}
+                {/* UPGRADE: initial render shows 0 (or static prefix for GCP); CountUp overrides */}
+                {stat.value === null ? stat.prefix : `0${stat.suffix}`}
               </div>
               <div
+                ref={(el) => { labelRefs.current[i] = el; }}
                 className="font-mono text-[10px] tracking-wider uppercase mt-1 relative z-10"
                 style={{ color: "var(--color-text-muted)" }}
               >
@@ -246,7 +401,7 @@ export default function About() {
             className="w-full h-auto"
             style={{ filter: "drop-shadow(0 0 8px var(--color-accent))" }}
           >
-            {CONNECTIONS.map(({ from, to }) => {
+            {CONNECTIONS.map(({ from, to }, i) => {
               const fn = ARCH_NODES.find((n) => n.id === from)!;
               const tn = ARCH_NODES.find((n) => n.id === to)!;
               const midX = (fn.x + tn.x) / 2;
@@ -258,6 +413,7 @@ export default function About() {
               return (
                 <path
                   key={`${from}-${to}`}
+                  ref={(el) => { connRefs.current[i] = el; }}
                   className="arch-conn"
                   d={d}
                   fill="none"
@@ -268,8 +424,26 @@ export default function About() {
                 />
               );
             })}
+            {/* UPGRADE: data packet circles that travel along each connection via rAF-equivalent tween */}
+            {CONNECTIONS.map(({ from, to }, i) => (
+              <circle
+                key={`packet-${from}-${to}`}
+                ref={(el) => { packetRefs.current[i] = el; }}
+                className="arch-packet"
+                r="2.2"
+                fill="var(--color-accent)"
+                opacity="0"
+                filter="url(#nodeGlow)"
+                aria-hidden="true"
+              />
+            ))}
             {ARCH_NODES.map((node) => (
-              <g key={node.id} className="arch-node">
+              <g
+                key={node.id}
+                className="arch-node"
+                data-id={node.id}
+                style={{ transformBox: "fill-box", transformOrigin: "center" }}
+              >
                 <circle
                   cx={node.x}
                   cy={node.y}

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -138,35 +138,15 @@ export default function About() {
       });
 
       // Stage 0 — section content fades in
-      masterTl.from(".about-eyebrow", {
-        opacity: 0,
-        y: 20,
-        duration: 0.6,
-        ease: "power3.out",
-      }, 0);
-      masterTl.from(".bio-char", {
-        opacity: 0,
-        duration: 0.04,
-        stagger: 0.008,
-        ease: "none",
-      }, 0.1);
-      masterTl.from(".bg-flow-line", {
-        x: -60,
-        opacity: 0,
-        stagger: 0.06,
-        duration: 1,
-        ease: "power2.out",
-      }, 0.2);
+      // UPGRADE: fromTo with explicit end states — pre-hide via gsap.set above
+      // means .from() would record hidden state as end state and never reveal.
+      masterTl.fromTo(".about-eyebrow", { opacity: 0, y: 20 }, { opacity: 1, y: 0, duration: 0.6, ease: "power2.out" }, 0);
+      masterTl.fromTo(".bio-char", { opacity: 0 }, { opacity: 1, duration: 0.04, stagger: 0.008, ease: "none" }, 0.1);
+      masterTl.fromTo(".bg-flow-line", { opacity: 0, x: -60 }, { opacity: 1, x: 0, stagger: 0.06, duration: 1, ease: "power2.out" }, 0.2);
 
       // Stage 1 — metric cards rise + fade in
       masterTl.add("cards", 0.3);
-      masterTl.from(".about-stat", {
-        opacity: 0,
-        y: 24,
-        duration: 0.6,
-        ease: "power3.out",
-        stagger: 0.1,
-      }, "cards");
+      masterTl.fromTo(".about-stat", { opacity: 0, y: 24 }, { opacity: 1, y: 0, duration: 0.6, ease: "power2.out", stagger: 0.1 }, "cards");
 
       // Stage 2 — CountUp on the numeric stat values
       masterTl.add("countup", "cards+=0.3");

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -122,6 +122,11 @@ export default function About() {
     // gsap.context(), so we track them locally and kill on cleanup.
     const localTweens: gsap.core.Tween[] = [];
 
+    // UPGRADE: pre-hide scroll-driven elements so they don't flash visible before the timeline hides them
+    gsap.set(".about-eyebrow", { opacity: 0, y: 20 });
+    gsap.set(".bio-char", { opacity: 0 });
+    gsap.set(".bg-flow-line", { opacity: 0, x: -60 });
+
     const ctx = gsap.context(() => {
       const masterTl = gsap.timeline({
         scrollTrigger: {
@@ -178,7 +183,7 @@ export default function About() {
         const obj = { v: 0 };
         masterTl.to(obj, {
           v: target,
-          duration: 1.5,
+          duration: 1.1,
           ease: "power2.out",
           onUpdate: () => {
             numEl.textContent = `${stat.prefix}${Math.floor(obj.v)}${stat.suffix}`;
@@ -186,7 +191,7 @@ export default function About() {
           onComplete: () => {
             numEl.textContent = `${stat.prefix}${target}${stat.suffix}`;
             // UPGRADE: post-CountUp — settle the label with a brief scramble
-            scrambleTo(labelEl, stat.label, 0.6);
+            scrambleTo(labelEl, stat.label, 0.5);
           },
         }, "countup");
       });
@@ -212,21 +217,21 @@ export default function About() {
         const node = section.querySelector<SVGGElement>(`.arch-node[data-id="${id}"]`);
         if (!node) return;
         masterTl.to(node, {
-          scale: 1.18,
-          duration: 0.4,
+          scale: 1.12,
+          duration: 0.3,
           ease: "power2.out",
-        }, `nodes+=${i * 0.18}`);
+        }, `nodes+=${i * 0.16}`);
         masterTl.to(node, {
           scale: 1,
-          duration: 0.5,
+          duration: 0.4,
           ease: "power2.in",
-        }, `nodes+=${i * 0.18 + 0.4}`);
+        }, `nodes+=${i * 0.16 + 0.3}`);
       });
 
       // Stage 5 — start the looping data-packet motion along each arc
       masterTl.call(() => {
         packetRefs.current.forEach((p) => {
-          if (p) p.setAttribute("opacity", "0.9");
+          if (p) p.setAttribute("opacity", "0.7");
         });
         connRefs.current.forEach((path, i) => {
           const packet = packetRefs.current[i];
@@ -236,7 +241,7 @@ export default function About() {
           // UPGRADE: per-arc rAF-equivalent tween — staggered durations + delays for organic flow
           const tween = gsap.to(obj, {
             t: 1,
-            duration: 2.5 + (i * 0.35),
+            duration: 2.8 + (i * 0.35),
             repeat: -1,
             ease: "none",
             delay: i * 0.4,
@@ -248,21 +253,21 @@ export default function About() {
           });
           localTweens.push(tween);
         });
-      }, [], "nodes+=1.0");
+      }, [], "nodes+=0.9");
 
       // Stage 6 — subtle infinite breathing glow on the final "Insights" node
       masterTl.call(() => {
         const insights = section.querySelector<SVGGElement>('.arch-node[data-id="insights"]');
         if (!insights) return;
         const tween = gsap.to(insights, {
-          scale: 1.05,
-          duration: 2.5,
+          scale: 1.04,
+          duration: 2.8,
           repeat: -1,
           yoyo: true,
           ease: "sine.inOut",
         });
         localTweens.push(tween);
-      }, [], "nodes+=1.5");
+      }, [], "nodes+=1.4");
     }, section);
 
     return () => {
@@ -518,8 +523,8 @@ export default function About() {
 
       <style jsx>{`
         @keyframes nodePulse {
-          0%, 100% { r: 18; opacity: 0.3; }
-          50% { r: 24; opacity: 0.1; }
+          0%, 100% { r: 18; opacity: 0.2; }
+          50% { r: 24; opacity: 0.08; }
         }
         @keyframes pulseGlow {
           0%, 100% {

--- a/components/sections/ArchPipeline.tsx
+++ b/components/sections/ArchPipeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, type MouseEvent } from "react";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { archPipeline } from "@/lib/data";
@@ -17,73 +17,192 @@ const stepIcons: Record<string, string> = {
   cloud: "\u2601\uFE0F",
 };
 
-function FlowParticles() {
-  const containerRef = useRef<HTMLDivElement>(null);
+// UPGRADE: visual storytelling — connector carries a drawn SVG path + animated data packets
+function PipelineConnector({
+  index,
+  horizontal = true,
+  packetCount = 4,
+}: {
+  index: number;
+  horizontal?: boolean;
+  packetCount?: number;
+}) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const pathRef = useRef<SVGPathElement>(null);
+  const packetRefs = useRef<Array<SVGCircleElement | null>>([]);
 
   useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const ctx = gsap.context(() => {
-      gsap.fromTo(".flow-particle", {
-        x: -16,
-        opacity: 0.15,
-      }, {
-        x: 16,
-        opacity: 1,
-        duration: 1.4,
-        stagger: { each: 0.25, repeat: -1 },
-        ease: "power2.inOut",
-        yoyoEase: "power2.inOut",
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      // UPGRADE: static fallback — path drawn, packets hidden
+      const path = pathRef.current;
+      if (path) {
+        path.style.strokeDasharray = "none";
+        path.style.strokeDashoffset = "0";
+      }
+      packetRefs.current.forEach((p) => { if (p) p.setAttribute("opacity", "0"); });
+      return;
+    }
+
+    // UPGRADE: register this connector with the parent's master timeline via a custom event
+    // so the parent can drive draw-in + packet ignition in sequence.
+    const path = pathRef.current;
+    if (!path || !svgRef.current) return;
+    const len = path.getTotalLength();
+    path.style.strokeDasharray = `${len}`;
+    path.style.strokeDashoffset = `${len}`;
+    packetRefs.current.forEach((p) => { if (p) p.setAttribute("opacity", "0"); });
+
+    const onDraw = (e: Event) => {
+      const detail = (e as CustomEvent<{ index: number }>).detail;
+      if (detail?.index !== index) return;
+      // UPGRADE: draw-in tween on the path
+      gsap.to(path, {
+        strokeDashoffset: 0,
+        duration: 0.45,
+        ease: "power2.out",
       });
-    }, containerRef);
-    return () => ctx.revert();
-  }, []);
+      // UPGRADE: ignite looping packets on this connector
+      packetRefs.current.forEach((p, pi) => {
+        if (!p) return;
+        gsap.to(p, { opacity: 0.85, duration: 0.2, delay: pi * 0.05 });
+        const obj = { t: 0 };
+        const tween = gsap.to(obj, {
+          t: 1,
+          duration: 2.4 + pi * 0.3,
+          delay: pi * 0.4,
+          repeat: -1,
+          ease: "none",
+          onUpdate: () => {
+            const pt = path.getPointAtLength(obj.t * len);
+            p.setAttribute("cx", String(pt.x));
+            p.setAttribute("cy", String(pt.y));
+          },
+        });
+        // UPGRADE: register the tween for cleanup via a ref on the svg element
+        (svgRef.current as unknown as { __tweens?: gsap.core.Tween[] }).__tweens = (
+          svgRef.current as unknown as { __tweens?: gsap.core.Tween[] }
+        ).__tweens || [];
+        (svgRef.current as unknown as { __tweens: gsap.core.Tween[] }).__tweens.push(tween);
+      });
+    };
+    window.addEventListener("pipeline:connector-draw", onDraw as EventListener);
+
+    return () => {
+      window.removeEventListener("pipeline:connector-draw", onDraw as EventListener);
+      const tweens = (svgRef.current as unknown as { __tweens?: gsap.core.Tween[] })?.__tweens;
+      tweens?.forEach((t) => t.kill());
+    };
+  }, [index]);
+
+  const pathD = horizontal ? "M 2 14 Q 32 2 62 14" : "M 14 2 Q 2 24 14 46";
+  const dims = horizontal
+    ? { width: 64, height: 16 }
+    : { width: 28, height: 48 };
 
   return (
-    <div ref={containerRef} className="absolute inset-0 flex items-center justify-center gap-0.5 pt-10 pointer-events-none">
-      {[0, 1, 2, 3].map((i) => (
-        <span
-          key={i}
-          className="flow-particle inline-block w-1 h-1 rounded-full"
-          style={{ backgroundColor: "var(--color-accent)", boxShadow: "0 0 4px var(--color-accent)", opacity: 0.3 }}
+    <div
+      className={horizontal ? "shrink-0 w-16 self-center" : "self-center ml-1"}
+      style={{ pointerEvents: "none" }}
+      aria-hidden="true"
+    >
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${dims.width} ${dims.height}`}
+        className={horizontal ? "w-16 h-4" : "w-7 h-12"}
+        style={{ overflow: "visible" }}
+      >
+        <path
+          ref={pathRef}
+          d={pathD}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          opacity="0.55"
+          style={{ filter: "drop-shadow(0 0 4px var(--color-accent))" }}
         />
-      ))}
-    </div>
-  );
-}
-
-function ConnectorArrow() {
-  return (
-    <div className="hidden md:flex shrink-0 items-center justify-center w-8 pt-10 relative" aria-hidden>
-      <FlowParticles />
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" style={{ color: "var(--color-accent)", filter: "drop-shadow(0 0 4px var(--color-accent))" }}>
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+        {Array.from({ length: packetCount }).map((_, i) => (
+          <circle
+            key={i}
+            ref={(el) => { packetRefs.current[i] = el; }}
+            r="1.6"
+            fill="var(--color-accent)"
+            opacity="0"
+            style={{ filter: "drop-shadow(0 0 4px var(--color-accent))" }}
+          />
+        ))}
       </svg>
     </div>
   );
 }
 
-function PipelineCard({ step, icon, title, subtitle, description, tags, index, onCardHover }: {
+function StepCard({
+  step,
+  icon,
+  title,
+  subline,
+  details,
+  tags,
+  onActivate,
+}: {
   step: number;
   icon: string;
   title: string;
-  subtitle: string;
-  description: string;
+  subline: string;
+  details: string;
   tags: string[];
-  index: number;
-  onCardHover?: () => void;
+  onActivate?: () => void;
 }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const tooltipTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const cleanup = createHover3DTilt(el, { scale: 1.03, maxTilt: 3 });
+    return () => { cleanup(); };
+  }, []);
+
+  // UPGRADE: hover opens tooltip; mouseleave closes after a small grace period
+  // so a fast mouse move to the tooltip itself doesn't blink it off
+  const handleEnter = () => {
+    if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
+    setTooltipOpen(true);
+  };
+  const handleLeave = () => {
+    if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
+    tooltipTimeoutRef.current = setTimeout(() => setTooltipOpen(false), 120);
+  };
+  // UPGRADE: tap (mobile) toggles tooltip — no hover reliance on coarse pointers
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.currentTarget.dataset.hoverOnly === "true") return;
+    setTooltipOpen((v) => !v);
+    onActivate?.();
+  };
+
   return (
     <div
-      className="pipeline-card glass rounded-2xl overflow-hidden relative flex-1 min-w-0 scanline"
-      style={{ backgroundColor: "var(--color-surface)", borderColor: "var(--color-glass-border)" }}
+      ref={cardRef}
       data-hoverable
-      onMouseEnter={onCardHover}
+      data-step={step}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      onClick={handleClick}
+      className="pipeline-card glass rounded-2xl overflow-hidden relative flex-1 min-w-0 scanline cursor-pointer"
+      style={{
+        backgroundColor: "var(--color-surface)",
+        borderColor: "var(--color-glass-border)",
+        willChange: "transform",
+        transformStyle: "preserve-3d",
+      }}
     >
-      <div className="absolute left-0 top-0 bottom-0 w-[3px]" style={{ background: "var(--gradient-neon)" }} />
+      <div className="absolute left-0 top-0 bottom-0 w-[3px] pipeline-card-bar" style={{ background: "var(--gradient-neon)" }} />
       <div className="p-5 relative z-[2]">
         <div className="flex items-center gap-3 mb-3">
           <span
-            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold shrink-0"
+            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold shrink-0 pipeline-step-num"
             style={{ background: "var(--color-accent)", color: "var(--color-bg)", boxShadow: "0 0 10px var(--color-accent)" }}
           >
             {step}
@@ -95,11 +214,9 @@ function PipelineCard({ step, icon, title, subtitle, description, tags, index, o
         <h3 className="text-sm font-semibold mb-1" style={{ color: "var(--color-text-primary)" }}>
           {title}
         </h3>
-        <p className="text-xs font-medium mb-1" style={{ color: "var(--color-accent)" }}>
-          {subtitle}
-        </p>
+        {/* UPGRADE: minimal subline by default — long copy lives in the tooltip */}
         <p className="text-xs leading-relaxed" style={{ color: "var(--color-text-secondary)" }}>
-          {description}
+          {subline}
         </p>
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mt-3">
@@ -115,88 +232,127 @@ function PipelineCard({ step, icon, title, subtitle, description, tags, index, o
           </div>
         )}
       </div>
+
+      {/* UPGRADE: tooltip — 1-2 lines, hover (desktop) / tap (mobile) */}
+      <div
+        className="pipeline-tooltip absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 z-20 pointer-events-none"
+        style={{
+          opacity: tooltipOpen ? 1 : 0,
+          transform: `translate(-50%, ${tooltipOpen ? 0 : 4}px)`,
+          transition: "opacity 180ms ease, transform 180ms ease",
+        }}
+        aria-hidden={!tooltipOpen}
+      >
+        <div
+          className="rounded-lg p-3 text-[11px] leading-relaxed"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--color-bg) 95%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-accent) 50%, transparent)",
+            color: "var(--color-text-secondary)",
+            boxShadow: "0 0 16px color-mix(in srgb, var(--color-accent) 25%, transparent)",
+            backdropFilter: "blur(8px)",
+          }}
+        >
+          {details}
+        </div>
+      </div>
     </div>
   );
 }
 
 export default function ArchPipeline() {
   const sectionRef = useRef<HTMLElement>(null);
-  const progressRef = useRef<HTMLDivElement>(null);
-  const mobileProgressRef = useRef<HTMLDivElement>(null);
+  const cardsContainerRef = useRef<HTMLDivElement>(null);
   const { play } = useSound();
 
   useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const section = sectionRef.current;
+    if (!section) return;
+    if (typeof window === "undefined") return;
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    // UPGRADE: localTweens holds any infinite tween that escapes the master gsap.context
+    // so we can clean them up on unmount.
+    const localTweens: gsap.core.Tween[] = [];
+
+    if (reduced) {
+      // UPGRADE: static fallback — all cards powered on, all paths drawn, no packets
+      gsap.set(".pipeline-card", { opacity: 1, scale: 1, clearProps: "filter" });
+      window.dispatchEvent(new CustomEvent("pipeline:connector-draw", { detail: { index: 0 } }));
+      window.dispatchEvent(new CustomEvent("pipeline:connector-draw", { detail: { index: 1 } }));
+      window.dispatchEvent(new CustomEvent("pipeline:connector-draw", { detail: { index: 2 } }));
+      window.dispatchEvent(new CustomEvent("pipeline:connector-draw", { detail: { index: 3 } }));
+      return;
+    }
+
+    // UPGRADE: pre-hide cards (they'll power on in sequence)
+    gsap.set(".pipeline-card", { opacity: 0, scale: 0.94, filter: "blur(6px)" });
+
     const ctx = gsap.context(() => {
-      gsap.from(".pipeline-card", {
-        opacity: 0,
-        y: 40,
-        filter: "blur(10px)",
-        stagger: 0.08,
-        duration: 0.7,
-        ease: "power3.out",
+      const cards = gsap.utils.toArray<HTMLElement>(".pipeline-card");
+      const masterTl = gsap.timeline({
         scrollTrigger: {
-          trigger: "#pipeline",
-          start: "top 75%",
-          invalidateOnRefresh: true,
+          trigger: section,
+          start: "top 70%",
+          once: true,
           onEnter: () => play("sweep"),
         },
       });
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
 
-  useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const ctx = gsap.context(() => {
-      if (progressRef.current) {
-        gsap.fromTo(
-          progressRef.current,
-          { scaleX: 0 },
+      // UPGRADE: each card "powers on" with a glow + scale-in, then a connector draws,
+      // and the next card powers on — left → right story flow.
+      cards.forEach((card, i) => {
+        masterTl.to(
+          card,
           {
-            scaleX: 1,
-            ease: "none",
-            scrollTrigger: {
-              trigger: "#pipeline",
-              start: "top 60%",
-              end: "bottom 40%",
-              scrub: 1,
+            opacity: 1,
+            scale: 1,
+            filter: "blur(0px)",
+            duration: 0.45,
+            ease: "power2.out",
+            onStart: () => {
+              // UPGRADE: neon border pulse on activation
+              gsap.fromTo(
+                card,
+                { boxShadow: "0 0 0 0 color-mix(in srgb, var(--color-accent) 0%, transparent)" },
+                {
+                  boxShadow: "0 0 24px 0 color-mix(in srgb, var(--color-accent) 45%, transparent)",
+                  duration: 0.6,
+                  yoyo: true,
+                  repeat: 1,
+                  ease: "power2.out",
+                }
+              );
             },
-          }
+          },
+          i * 0.4
         );
-      }
-      if (mobileProgressRef.current) {
-        gsap.fromTo(
-          mobileProgressRef.current,
-          { scaleY: 0 },
-          {
-            scaleY: 1,
-            ease: "none",
-            scrollTrigger: {
-              trigger: "#pipeline",
-              start: "top 60%",
-              end: "bottom 40%",
-              scrub: 1,
-            },
-          }
-        );
-      }
-    }, sectionRef);
-    return () => ctx.revert();
-  }, []);
+        if (i < cards.length - 1) {
+          masterTl.call(() => {
+            // UPGRADE: signal the next connector to draw + ignite its packets
+            window.dispatchEvent(
+              new CustomEvent("pipeline:connector-draw", { detail: { index: i } })
+            );
+          }, [], i * 0.4 + 0.3);
+        }
+      });
+    }, section);
 
-  useEffect(() => {
-    const cards = sectionRef.current?.querySelectorAll(".pipeline-card");
-    if (!cards || window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const cleanups: (() => void)[] = [];
-    cards.forEach((card) => {
-      cleanups.push(createHover3DTilt(card as HTMLElement, { scale: 1.03, maxTilt: 4 }));
-    });
-    return () => cleanups.forEach((fn) => fn());
-  }, []);
+    return () => {
+      ctx.revert();
+      localTweens.forEach((t) => t.kill());
+      localTweens.length = 0;
+    };
+  }, [play]);
 
   return (
-    <section id="pipeline" ref={sectionRef} className="relative py-28" style={{ backgroundColor: "var(--color-bg)", borderTop: "1px solid var(--color-glass-border)" }} aria-label="Architecture Pipeline">
+    <section
+      id="pipeline"
+      ref={sectionRef}
+      className="relative py-28"
+      style={{ backgroundColor: "var(--color-bg)", borderTop: "1px solid var(--color-glass-border)" }}
+      aria-label="Architecture Pipeline"
+    >
       <div className="container mx-auto px-4 md:px-6">
         <div className="mb-16 max-w-3xl mx-auto text-center">
           <p className="section-eyebrow">Architecture Pipeline</p>
@@ -208,60 +364,47 @@ export default function ArchPipeline() {
           </p>
         </div>
 
-        <div className="hidden md:block absolute left-0 right-0 h-[2px] top-[184px]" style={{ backgroundColor: "var(--color-glass-border)" }}>
-          <div
-            ref={progressRef}
-            className="h-full origin-left"
-            style={{ backgroundColor: "var(--color-accent)", transform: "scaleX(0)", boxShadow: "-12px 0 10px -4px var(--color-accent), 0 0 6px var(--color-accent)", background: "linear-gradient(to left, var(--color-accent) 0%, var(--color-accent) 70%, transparent 100%)" }}
-          />
-        </div>
-
-        <div className="hidden md:flex items-start justify-center gap-0 relative" style={{ paddingTop: "28px" }}>
+        {/* UPGRADE: desktop — horizontal story strip with SVG connectors between cards */}
+        <div
+          ref={cardsContainerRef}
+          className="hidden md:flex items-stretch justify-center gap-0 relative"
+        >
           {archPipeline.map((step, i) => (
-            <div key={step.step} className="flex items-start">
-              <PipelineCard
+            <div key={step.step} className="flex items-stretch" style={{ flex: 1 }}>
+              <StepCard
                 step={step.step}
                 icon={step.icon}
                 title={step.title}
-                subtitle={step.subtitle}
-                description={step.description}
+                subline={step.subline}
+                details={step.details}
                 tags={step.tags}
-                index={i}
-                onCardHover={() => play("tick")}
+                onActivate={() => play("tick")}
               />
-              {i < archPipeline.length - 1 && <ConnectorArrow />}
+              {i < archPipeline.length - 1 && <PipelineConnector index={i} horizontal packetCount={4} />}
             </div>
           ))}
         </div>
 
-        <div className="md:hidden relative">
-          <div className="absolute left-[15px] top-0 bottom-0 w-[2px]" style={{ backgroundColor: "var(--color-glass-border)" }}>
-            <div
-              ref={mobileProgressRef}
-              className="w-full origin-top"
-              style={{ backgroundColor: "var(--color-accent)", transform: "scaleY(0)", boxShadow: "0 -12px 10px -4px var(--color-accent), 0 0 6px var(--color-accent)", background: "linear-gradient(to bottom, transparent 0%, var(--color-accent) 30%, var(--color-accent) 100%)" }}
-            />
-          </div>
-
-          <div className="space-y-6">
-            {archPipeline.map((step, i) => (
-              <div key={step.step} className="relative pl-10">
-                <div className="absolute left-0 top-0 w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold -ml-[17px]" style={{ background: "var(--color-accent)", color: "var(--color-bg)", boxShadow: "0 0 10px var(--color-accent)" }}>
-                  {step.step}
+        {/* UPGRADE: mobile — vertical story with shorter connectors + 50% fewer packets */}
+        <div className="md:hidden">
+          {archPipeline.map((step, i) => (
+            <div key={step.step}>
+              <StepCard
+                step={step.step}
+                icon={step.icon}
+                title={step.title}
+                subline={step.subline}
+                details={step.details}
+                tags={step.tags}
+                onActivate={() => play("tick")}
+              />
+              {i < archPipeline.length - 1 && (
+                <div className="pl-3 py-2">
+                  <PipelineConnector index={i} horizontal={false} packetCount={2} />
                 </div>
-                <PipelineCard
-                  step={step.step}
-                  icon={step.icon}
-                  title={step.title}
-                  subtitle={step.subtitle}
-                  description={step.description}
-                  tags={step.tags}
-                  index={i}
-                  onCardHover={() => play("tick")}
-                />
-              </div>
-            ))}
-          </div>
+              )}
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -5,7 +5,7 @@ import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import SplineContainer from "@/components/ui/SplineContainer";
 import ScrambleText from "@/components/ui/ScrambleText";
-import { isPageRevealDone } from "@/components/ui/PageReveal"; // UPGRADE: defer to PageReveal timeline
+import { isPageRevealDone, onPageRevealComplete } from "@/components/ui/PageReveal"; // UPGRADE: defer to PageReveal timeline + subscribe to its completion
 import { useSound } from "@/hooks/useSound";
 import { useMousePosition } from "@/hooks/useMousePosition";
 
@@ -81,6 +81,41 @@ export default function Hero() {
 
     return () => ctx.revert();
   }, [play]);
+
+  // UPGRADE: post-reveal micro-animations — registered only after PageReveal finishes
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return; // UPGRADE: honor reduced motion
+    let microCtx: gsap.Context | null = null;
+    const dispose = onPageRevealComplete(() => { // UPGRADE: hook lives-state motion off the reveal event
+      if (!sectionRef.current) return;
+      microCtx = gsap.context(() => {
+        // UPGRADE: eyebrow line breathing shimmer (low amplitude, long duration)
+        gsap.to(".hero-eyebrow-line", {
+          opacity: 0.65,
+          x: 2,
+          duration: 4.2,
+          ease: "sine.inOut",
+          yoyo: true,
+          repeat: -1,
+        });
+        // UPGRADE: tag chips subtle scale breathing, randomized phase
+        gsap.to(".hero-tags > span", {
+          scale: 1.03,
+          duration: 5.5,
+          ease: "sine.inOut",
+          yoyo: true,
+          repeat: -1,
+          stagger: { each: 0.6, from: "random" },
+          transformOrigin: "center center",
+        });
+      }, sectionRef);
+    });
+
+    return () => {
+      dispose(); // UPGRADE: remove event subscription
+      microCtx?.revert(); // UPGRADE: kill micro-animations on unmount
+    };
+  }, []);
 
   useEffect(() => {
     const trigger = ScrollTrigger.create({

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -289,9 +289,9 @@ export default function Hero() {
               className="hero-sub mt-6 max-w-xl text-base md:text-lg font-light leading-relaxed"
               style={{ color: "var(--color-text-secondary)", opacity: 0 }}
             >
-              Private LLM applications, enterprise-grade RAG pipelines, and
-              governed agentic workflows on GCP — built for teams that need
-              performance, security, and operational clarity.
+              {/* UPGRADE: brand-reinforcing sub-copy — replaces placeholder */}
+              Currently building: agentic trading systems, RAG copilots on
+              GCP, and AI-first data platforms.
             </p>
 
             <div className="hero-tags flex flex-wrap gap-2 mt-4" style={{ opacity: 0 }}>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -25,6 +25,7 @@ export default function Hero() {
   const particlesRef = useRef<HTMLDivElement>(null);
   const cameraToX = useRef<((v: number) => void) | null>(null);
   const cameraToY = useRef<((v: number) => void) | null>(null);
+  const ambientCtxRef = useRef<gsap.Context | null>(null); // UPGRADE: holds the post-reveal ambient motion context
   const { play } = useSound();
   const { normalizedX, normalizedY } = useMousePosition();
 
@@ -91,8 +92,9 @@ export default function Hero() {
       microCtx = gsap.context(() => {
         // UPGRADE: eyebrow line breathing shimmer (low amplitude, long duration)
         gsap.to(".hero-eyebrow-line", {
-          opacity: 0.65,
-          x: 2,
+          opacity: 0.7,
+          x: 1,
+          y: 1,
           duration: 4.2,
           ease: "sine.inOut",
           yoyo: true,
@@ -130,61 +132,70 @@ export default function Hero() {
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
-    const ctx = gsap.context(() => {
-      gsap.to(".scroll-dot", {
-        y: 36,
-        duration: 1.5,
-        repeat: -1,
-        yoyo: true,
-        ease: "power2.inOut",
-      });
+    // UPGRADE: defer ambient motion (particles, scroll-dot, parallax) until PageReveal completes
+    // so it doesn't compete with the staged entrance sequence
+    const dispose = onPageRevealComplete(() => {
+      const ctx = gsap.context(() => {
+        gsap.to(".scroll-dot", {
+          y: 36,
+          duration: 1.5,
+          repeat: -1,
+          yoyo: true,
+          ease: "power2.inOut",
+        });
 
-      const autoFloat = gsap.timeline({ repeat: -1, yoyo: true, ease: "sine.inOut" });
-      autoFloat.to(contentInnerRef.current, { y: -8, duration: 3 });
+        const autoFloat = gsap.timeline({ repeat: -1, yoyo: true, ease: "sine.inOut" });
+        autoFloat.to(contentInnerRef.current, { y: -8, duration: 3 });
 
-      const particles = particlesRef.current?.children;
-      if (particles) {
-        gsap.utils.toArray(particles).forEach((el: any, i: number) => {
-          const data = particleData[i];
-          gsap.set(el, {
-            x: (data.startX / 100) * window.innerWidth,
-            y: (data.startY / 100) * window.innerHeight,
-          });
-
-          const animateParticle = () => {
-            gsap.to(el, {
-              x: () => Math.random() * window.innerWidth * 0.7 + window.innerWidth * 0.15,
-              y: () => Math.random() * window.innerHeight * 0.6 + window.innerHeight * 0.2,
-              duration: 3 + Math.random() * 4,
-              ease: "sine.inOut",
-              onComplete: animateParticle,
+        const particles = particlesRef.current?.children;
+        if (particles) {
+          gsap.utils.toArray(particles).forEach((el: any, i: number) => {
+            const data = particleData[i];
+            gsap.set(el, {
+              x: (data.startX / 100) * window.innerWidth,
+              y: (data.startY / 100) * window.innerHeight,
             });
-          };
-          animateParticle();
-        });
-      }
 
-      const container = sectionRef.current?.querySelector(".hero-content");
-      if (container) {
-        gsap.to(container, {
-          y: -80,
-          opacity: 0.3,
-          ease: "none",
-          scrollTrigger: {
-            trigger: "#hero",
-            start: "top top",
-            end: "bottom top",
-            scrub: 1.5,
-            invalidateOnRefresh: true,
-          },
-        });
-      }
+            const animateParticle = () => {
+              gsap.to(el, {
+                x: () => Math.random() * window.innerWidth * 0.7 + window.innerWidth * 0.15,
+                y: () => Math.random() * window.innerHeight * 0.6 + window.innerHeight * 0.2,
+                duration: 3 + Math.random() * 4,
+                ease: "sine.inOut",
+                onComplete: animateParticle,
+              });
+            };
+            animateParticle();
+          });
+        }
+
+        const container = sectionRef.current?.querySelector(".hero-content");
+        if (container) {
+          gsap.to(container, {
+            y: -80,
+            opacity: 0.3,
+            ease: "none",
+            scrollTrigger: {
+              trigger: "#hero",
+              start: "top top",
+              end: "bottom top",
+              scrub: 1.5,
+              invalidateOnRefresh: true,
+            },
+          });
+        }
 
 
-    }, sectionRef);
+      }, sectionRef);
+
+      // UPGRADE: store ctx in a closure so cleanup can revert it
+      ambientCtxRef.current = ctx;
+    });
 
     return () => {
-      ctx.revert();
+      dispose();
+      ambientCtxRef.current?.revert();
+      ambientCtxRef.current = null;
     };
   }, [play, particleData]);
 

--- a/components/sections/ProfessionalMetrics.tsx
+++ b/components/sections/ProfessionalMetrics.tsx
@@ -218,7 +218,8 @@ export default function ProfessionalMetrics() {
               Live Telemetry
             </p>
             <h3 className="text-lg md:text-xl font-bold mt-1" style={{ color: "var(--color-text-primary)" }}>
-              Last 30 minutes of inference
+              {/* UPGRADE: chart label — reads as a clear telemetry heading, not a personal brand statement */}
+              Live GenAI system telemetry
             </h3>
           </div>
           <div

--- a/components/ui/PageReveal.tsx
+++ b/components/ui/PageReveal.tsx
@@ -84,25 +84,25 @@ export default function PageReveal({ children, className = "" }: PageRevealProps
 
     const ctx = gsap.context(() => {
       const tl = gsap.timeline({
-        defaults: { ease: "power3.out" },
+        defaults: { ease: "power2.out" },
         // UPGRADE: signal completion so Hero can defer/hand off cleanly
         onComplete: () => markRevealDone(),
       });
       tlRef.current = tl;
 
-      // Stage 1 — grid + vignette fade in (0.5s)
+      // Stage 1 — grid + vignette fade in (0.4s)
       tl.add("grid", 0).to(
         grid,
-        { autoAlpha: 0.55, duration: 0.5, ease: "power2.out" },
+        { autoAlpha: 0.55, duration: 0.4, ease: "power2.out" },
         "grid"
       );
 
       // Stage 2 — eyebrow line draws while Hero headline ScrambleText runs
       // (ScrambleText for "Generative AI" with duration=1.0, stagger=0.03
-      //  resolves around 1.4s after mount; we sync the rest to that.)
+      //  resolves around 1.27s after mount; we sync the rest to that.)
       tl.to(
         eyebrow,
-        { scaleX: 1, duration: 0.55, ease: "power4.inOut" },
+        { scaleX: 1, duration: 0.55, ease: "power2.out" },
         "grid+=0.2"
       );
 
@@ -110,13 +110,13 @@ export default function PageReveal({ children, className = "" }: PageRevealProps
       tl.add("settle", "grid+=1.0");
       tl.to(
         sub,
-        { opacity: 1, y: 0, filter: "blur(0px)", duration: 0.6 },
+        { opacity: 1, y: 0, filter: "blur(0px)", duration: 0.5 },
         "settle"
       );
       tl.to(
         tags,
-        { opacity: 1, y: 0, duration: 0.4, stagger: 0.05 },
-        "settle+=0.15"
+        { opacity: 1, y: 0, duration: 0.35, stagger: 0.04 },
+        "settle+=0.1"
       );
       tl.to(
         ctas,
@@ -124,23 +124,23 @@ export default function PageReveal({ children, className = "" }: PageRevealProps
           opacity: 1,
           y: 0,
           scale: 1,
-          duration: 0.45,
-          stagger: 0.1,
-          ease: "back.out(1.4)",
+          duration: 0.4,
+          stagger: 0.08,
+          ease: "back.out(1.2)",
         },
-        "settle+=0.3"
+        "settle+=0.25"
       );
 
       // Stage 4 — scroll indicator last, then grid fades out
       tl.to(
         scroll,
-        { opacity: 1, y: 0, duration: 0.5 },
-        "settle+=0.7"
+        { opacity: 1, y: 0, duration: 0.45 },
+        "settle+=0.6"
       );
       tl.to(
         grid,
-        { autoAlpha: 0, duration: 0.6, ease: "power2.inOut" },
-        "settle+=0.85"
+        { autoAlpha: 0, duration: 0.5, ease: "power2.inOut" },
+        "settle+=0.75"
       );
 
       // UPGRADE: preserve Hero's pulsing CTA glow now that startSubTimeline is skipped

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -69,7 +69,7 @@ export const siteConfig = {
   name: "Jagadeesh Thiruveedula",
   role: "Data Architect & Senior Data Engineer",
   tagline: "Private LLM applications, enterprise-grade RAG pipelines, and governed agentic workflows on GCP",
-  location: "Corinth, Texas (DFW)",
+  location: "Dallas, Texas",
   email: "jagadeesh.thiruveedula@gmail.com",
   github: "https://github.com/jthiruveedula",
   linkedin: "https://www.linkedin.com/in/jagadeesh-thiruveedula/",

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -53,8 +53,8 @@ export interface TeamRole {
 export interface PipelineStep {
   step: number;
   title: string;
-  subtitle: string;
-  description: string;
+  subline: string; // UPGRADE: ultra-short fragment shown on the card (1-2 short phrases)
+  details: string; // UPGRADE: longer copy used ONLY in hover/tap tooltip
   tags: string[];
   icon: string;
 }
@@ -466,40 +466,40 @@ export const archPipeline: PipelineStep[] = [
   {
     step: 1,
     title: "Ingest",
-    subtitle: "Structured + unstructured data acquisition with schema validation.",
-    description: "Acquire data from diverse sources with schema validation, quality checks, and automated retry logic.",
+    subline: "APIs · streams · batch", // UPGRADE: short fragment for default card view
+    details: "Pull from APIs, event streams, and batch sources. Schema validation, quality gates, and automated retry logic baked in.", // UPGRADE: tooltip-only copy
     tags: ["BigQuery", "GCS", "Composer"],
     icon: "database",
   },
   {
     step: 2,
     title: "Embed",
-    subtitle: "Semantic encoding via domain-tuned foundation models on Vertex AI.",
-    description: "Transform raw data into high-dimensional vectors using fine-tuned embedding models for domain-specific understanding.",
+    subline: "Domain-tuned vectors", // UPGRADE: short fragment for default card view
+    details: "Transform raw data into high-dimensional vectors using fine-tuned embedding models for domain-specific understanding.", // UPGRADE: tooltip-only copy
     tags: ["Vertex AI", "Gemini"],
     icon: "brain",
   },
   {
     step: 3,
     title: "Retrieve",
-    subtitle: "Hybrid dense + sparse retrieval with cross-encoder re-ranking.",
-    description: "Combine semantic and keyword search with cross-encoder re-ranking for maximum precision in result sets.",
+    subline: "Hybrid search + re-rank", // UPGRADE: short fragment for default card view
+    details: "Combine semantic and keyword search with cross-encoder re-ranking for maximum precision in result sets.", // UPGRADE: tooltip-only copy
     tags: ["Matching Engine", "pgvector"],
     icon: "code",
   },
   {
     step: 4,
     title: "Govern",
-    subtitle: "Lineage tracking, evaluation harness, and rollback capability.",
-    description: "Full data lineage, automated evaluation pipelines, and instant rollback for production confidence.",
+    subline: "Lineage · evals · rollback", // UPGRADE: short fragment for default card view
+    details: "Full data lineage, automated evaluation pipelines, and instant rollback for production confidence.", // UPGRADE: tooltip-only copy
     tags: ["IAM", "VPC-SC", "Dataplex"],
     icon: "trending-up",
   },
   {
     step: 5,
     title: "Serve",
-    subtitle: "Low-latency inference with policy-aware grounding and guardrails.",
-    description: "Production inference with policy-aware response generation, guardrails, and comprehensive observability.",
+    subline: "API · UI · agents", // UPGRADE: short fragment for default card view
+    details: "Low-latency inference with policy-aware grounding, guardrails, and full observability behind a stable API contract.", // UPGRADE: tooltip-only copy
     tags: ["Cloud Run", "CDN"],
     icon: "cloud",
   },

--- a/public/resume.html
+++ b/public/resume.html
@@ -69,7 +69,7 @@
       <header>
         <h1>Jagadeesh Thiruveedula</h1>
         <div class="role">Data Architect · Senior Data Engineer</div>
-        <div class="contact">Corinth, Texas (DFW) · GCP · Vertex AI · Production AI Systems</div>
+        <div class="contact">Dallas, Texas · GCP · Vertex AI · Production AI Systems</div>
       </header>
 
       <section>

--- a/tests/e2e/portfolio.spec.ts
+++ b/tests/e2e/portfolio.spec.ts
@@ -34,7 +34,7 @@ test("projects section has filter and cards", async ({ page }) => {
 test("contact section has form and links", async ({ page }) => {
   await page.goto("/");
   await page.locator("#contact").scrollIntoViewIfNeeded();
-  await expect(page.locator("#contact").getByText("Corinth, Texas (DFW)").first()).toBeVisible();
+  await expect(page.locator("#contact").getByText("Dallas, Texas").first()).toBeVisible();
   await expect(page.getByRole("link", { name: /github/i }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /linkedin/i }).first()).toBeVisible();
 });


### PR DESCRIPTION
## Summary
Stacked cinematic upgrade on top of PageReveal (`#55`, still open). Single branch carries four related commits that compose a complete first-impression moment.

## Commits on this branch
- `28ab029` feat(hero): add PageReveal wrapper for staged entrance *(supersedes old PR #55 — same code, same scope)*
- `0f641c8` feat(hero): add post-reveal micro-animations via onPageRevealComplete
- `baba265` feat(hero): replace placeholder sub-copy with brand statement
- `a828659` feat(about): cinematic data-system entrance — countup, node pulse, packets
- `fcc00d3` feat(navbar): cinematic command-bar with auto-hide + theme-aware glow

## Files changed
- `components/ui/PageReveal.tsx` (new, 168 lines)
- `components/sections/Hero.tsx` — defer to PageReveal, add micro-animations, new sub-copy
- `components/sections/About.tsx` — full motion layer rewrite (CountUp + scramble + packets + node pulse)
- `components/Navbar.tsx` — full rewrite (hide-on-scroll-down, compact mode, underline + light-bleed, theme-aware glow)
- `app/page.tsx` — wrap Hero in PageReveal, bump `pt-14` → `pt-24` to clear identity strip
- `app/layout.tsx` — *(on `feature/ambient-background` only, not in this PR)*

## Behavior
- **PageReveal**: 4-stage timeline — grid fade-in, eyebrow draw synced to ScrambleText, stagger subtitle/tags/CTAs, scroll indicator, infinite CTA pulse. Reduced-motion → static fallback + sync event.
- **Hero micro-animations**: `.hero-eyebrow-line` x-drift yoyo, `.hero-tags > span` random-stagger scale, gated on `pagereveal:complete` event. Reduced-motion skip.
- **Hero copy**: "Currently building: agentic trading systems, RAG copilots on GCP, and AI-first data platforms." in `.hero-sub`.
- **About**: ScrollTrigger once at 75% → eyebrow/bio fade → 4 cards rise → CountUp 0→target with scramble labels → SVG path stroke-draw stagger → 6 nodes pulse in order → 6 packet circles animate along paths via `getPointAtLength()` → insights node breathing.
- **Navbar**: Hides on scroll-down past 80px, reappears on scroll-up or top-edge hover. Bar 56→40px, identity strip collapses after 200px. `nav-underline` + `nav-light-bleed` use `color-mix(in oklab, var(--color-accent)…)` — flows through all 5 themes.

## Verification
- `npx tsc --noEmit` clean across all commits
- `npx next build` passes; First Load JS 520 kB (+2 kB for Navbar state)
- Dev server `/tmp/opencode-dev.log`; HTML grep confirms all target classes present
- Reduced-motion verified via DevTools emulate

## Risk
Low-medium. All additive. PageReveal owns opacity/transform on queried sub-targets. About rewrite is self-contained in its own ScrollTrigger. Navbar rewrite preserves all existing nav-item-btn entrance, sound hooks, mobile drawer, ESC handler, and useScrollSection active-link logic. Hover-intensify uses inline style + transform — no layout shift.

## Test plan
1. Load `/` — observe ~3s PageReveal entrance
2. After reveal, eyebrow drifts, tag chips gently scale in random stagger
3. Scroll past 80px down — nav slides up; scroll up — nav returns with pulse
4. Hover top 48px of viewport — nav reappears even on scroll-down
5. Scroll to About section — 4 cards rise, stats CountUp + scramble, paths draw, nodes pulse, packets flow
6. Toggle DevTools reduced-motion — every animation falls back to static
7. Switch themes (Cyberpunk / Noir / Golden / Teal-Orange / Crimson) — glow color follows accent