### PR TITLE
feat(ui): themed skeleton screens for lazy-loaded sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ playwright-report/
 /blob-report/
 /playwright/.cache/
 
+# Local audit screenshots (not committed)
+audit-screenshots/
+
 # Tooling artifacts
 .opencode/
 .codegraph/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import tseslint from 'typescript-eslint'
 import globals from 'globals'
 
 export default tseslint.config(
-  { ignores: ['out/**', 'dist/**', 'node_modules/**', 'test-results/**', 'playwright-report/**', 'docs/**'] },
+  { ignores: ['out/**', 'dist/**', 'node_modules/**', 'test-results/**', 'playwright-report/**', 'docs/**', 'scripts/audit-screenshots.mjs'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/scripts/audit-screenshots.mjs
+++ b/scripts/audit-screenshots.mjs
@@ -1,0 +1,65 @@
+/* eslint-env node */
+import { chromium } from 'playwright'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+const url = process.argv[2] || 'https://jthiruveedula.github.io/'
+const outDir = process.argv[3] || './audit-screenshots'
+const passName = process.argv[4] || 'baseline'
+
+const viewports = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 390, height: 844 },
+]
+
+async function main() {
+  const dir = path.resolve(outDir, passName)
+  await mkdir(dir, { recursive: true })
+
+  const browser = await chromium.launch({ headless: true })
+
+  for (const vp of viewports) {
+    const context = await browser.newContext({
+      viewport: { width: vp.width, height: vp.height },
+      deviceScaleFactor: 1,
+    })
+    const page = await context.newPage()
+
+    console.log(`[${passName}] Loading ${url} at ${vp.name} (${vp.width}x${vp.height})`)
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 })
+
+    // Wait for React hydration + hero animations to start
+    await page.waitForTimeout(2500)
+
+    // Scroll through the page to trigger lazy sections and scroll animations
+    await page.evaluate(async () => {
+      const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+      const step = window.innerHeight * 0.6
+      const max = document.body.scrollHeight - window.innerHeight
+      for (let y = 0; y <= max; y += step) {
+        window.scrollTo(0, y)
+        await delay(400)
+      }
+      window.scrollTo(0, 0)
+    })
+
+    // Let final animations settle after scroll reset
+    await page.waitForTimeout(1200)
+
+    const fileName = `${passName}-${vp.name}-${vp.width}x${vp.height}.png`
+    const filePath = path.join(dir, fileName)
+    await page.screenshot({ path: filePath, fullPage: true })
+    console.log(`  → ${filePath}`)
+
+    await context.close()
+  }
+
+  await browser.close()
+  console.log(`Done: ${dir}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,20 +5,13 @@ import Atmosphere from '@/components/Atmosphere'
 import CustomCursor from '@/components/CustomCursor'
 import ScrollProgress from '@/components/ScrollProgress'
 import SignalPath from '@/components/SignalPath'
+import SectionSkeleton from '@/components/SectionSkeleton'
 
 const Timeline = lazy(() => import('@/components/Timeline'))
 const SkillsConstellation = lazy(() => import('@/components/SkillsConstellation'))
 const Projects = lazy(() => import('@/components/Projects'))
 const Metrics = lazy(() => import('@/components/Metrics'))
 const Contact = lazy(() => import('@/components/Contact'))
-
-function SectionFallback({ label }: { label: string }) {
-  return (
-    <div className="flex min-h-[40vh] items-center justify-center" role="status" aria-label={`Loading ${label}`}>
-      <span className="hud-label animate-pulse">loading {label}…</span>
-    </div>
-  )
-}
 
 export default function App() {
   return (
@@ -33,19 +26,19 @@ export default function App() {
       <Navigation />
       <main id="main">
         <Hero />
-        <Suspense fallback={<SectionFallback label="timeline" />}>
+        <Suspense fallback={<SectionSkeleton variant="timeline" label="timeline" />}>
           <Timeline />
         </Suspense>
-        <Suspense fallback={<SectionFallback label="skills" />}>
+        <Suspense fallback={<SectionSkeleton variant="skills" label="skills" />}>
           <SkillsConstellation />
         </Suspense>
-        <Suspense fallback={<SectionFallback label="projects" />}>
+        <Suspense fallback={<SectionSkeleton variant="projects" label="projects" />}>
           <Projects />
         </Suspense>
-        <Suspense fallback={<SectionFallback label="impact" />}>
+        <Suspense fallback={<SectionSkeleton variant="metrics" label="impact" />}>
           <Metrics />
         </Suspense>
-        <Suspense fallback={<SectionFallback label="contact" />}>
+        <Suspense fallback={<SectionSkeleton variant="contact" label="contact" />}>
           <Contact />
         </Suspense>
       </main>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -343,7 +343,7 @@ export default function Navigation() {
                     {navIndex(i)}
                   </span>
                   <span
-                    className={`font-display text-4xl font-semibold transition-colors ${
+                    className={`press-feedback font-display text-4xl font-semibold transition-colors ${
                       activeId === item.id ? 'text-ink' : 'text-ink-muted group-hover:text-ink'
                     }`}
                   >

--- a/src/components/SectionSkeleton.tsx
+++ b/src/components/SectionSkeleton.tsx
@@ -1,0 +1,203 @@
+import type { ReactElement, ReactNode } from 'react'
+
+/**
+ * Themed skeleton placeholders for lazy-loaded sections.
+ *
+ * Instead of a generic "loading…" pulse, each variant mirrors the final
+ * section's layout so the page keeps its structure while chunks stream in.
+ * Shimmer bands move across the HUD surfaces to signal activity.
+ */
+
+type SkeletonVariant = 'timeline' | 'skills' | 'projects' | 'metrics' | 'contact'
+
+function Shimmer({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`skeleton-shimmer block rounded ${className ?? ''}`}
+    />
+  )
+}
+
+function HeaderBlock() {
+  return (
+    <div className="max-w-3xl space-y-4">
+      <Shimmer className="h-4 w-32" />
+      <Shimmer className="h-10 w-4/5 md:h-14" />
+      <Shimmer className="h-4 w-full" />
+      <Shimmer className="h-4 w-5/6" />
+    </div>
+  )
+}
+
+function GlassCard({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={`rounded-xl border border-panel-edge/60 bg-panel/40 p-5 md:p-6 ${className ?? ''}`}>
+      {children}
+    </div>
+  )
+}
+
+function TimelineSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-6xl px-6 py-24 md:py-32">
+      <HeaderBlock />
+      <div className="relative mt-16 md:mt-20">
+        <div className="pointer-events-none absolute inset-y-0 left-5 w-0.5 -translate-x-1/2 bg-panel-edge/70 md:left-1/2" />
+        <div className="space-y-10 md:space-y-14">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className={`relative pl-14 md:w-[calc(50%-3rem)] ${
+                i % 2 === 0 ? 'md:mr-auto' : 'md:ml-auto'
+              }`}
+            >
+              <span className="absolute top-6 left-5 z-10 h-3.5 w-3.5 -translate-x-1/2 rounded-full border-2 border-void bg-panel-edge md:left-1/2" />
+              <GlassCard className="space-y-4">
+                <div className="flex flex-wrap items-center gap-3">
+                  <Shimmer className="h-5 w-20" />
+                  <Shimmer className="h-4 w-32" />
+                </div>
+                <Shimmer className="h-6 w-3/4" />
+                <Shimmer className="h-4 w-1/2" />
+                <div className="flex flex-wrap gap-2 pt-2">
+                  <Shimmer className="h-8 w-24" />
+                  <Shimmer className="h-8 w-28" />
+                  <Shimmer className="h-8 w-20" />
+                </div>
+              </GlassCard>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SkillsSkeleton() {
+  return (
+    <div className="relative mx-auto max-w-6xl px-4 py-24 sm:px-6 md:py-32">
+      <HeaderBlock />
+      <div className="mt-10 h-[420px] overflow-hidden rounded-2xl border border-panel-edge/60 bg-panel/30 md:h-[540px]">
+        <div className="flex h-full items-center justify-center">
+          <div className="text-center">
+            <Shimmer className="mx-auto h-12 w-48" />
+            <Shimmer className="mx-auto mt-4 h-4 w-64" />
+          </div>
+        </div>
+      </div>
+      <div className="mt-10 flex flex-wrap gap-2">
+        {Array.from({ length: 18 }).map((_, i) => (
+          <Shimmer key={i} className="h-9 w-20 rounded-full" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ProjectsSkeleton() {
+  return (
+    <div className="relative mx-auto w-full max-w-6xl px-6 py-24 lg:py-32">
+      <HeaderBlock />
+      <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2">
+        <Shimmer className="h-4 w-20" />
+        <Shimmer className="h-4 w-20" />
+        <Shimmer className="h-4 w-28" />
+      </div>
+      <div className="mt-14 grid gap-6 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <GlassCard key={i} className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Shimmer className="h-5 w-20 rounded-full" />
+              <Shimmer className="h-4 w-24" />
+            </div>
+            <Shimmer className="h-7 w-3/4" />
+            <Shimmer className="h-4 w-full" />
+            <Shimmer className="h-4 w-5/6" />
+            <div className="aspect-[16/10] w-full overflow-hidden rounded-lg border border-panel-edge/40 bg-panel/50">
+              <Shimmer className="h-full w-full rounded-none" />
+            </div>
+            <div className="flex flex-wrap gap-2 pt-2">
+              <Shimmer className="h-6 w-16" />
+              <Shimmer className="h-6 w-20" />
+              <Shimmer className="h-6 w-14" />
+              <Shimmer className="h-6 w-18" />
+            </div>
+          </GlassCard>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MetricsSkeleton() {
+  return (
+    <div className="relative mx-auto max-w-6xl px-6 py-24 md:py-32">
+      <HeaderBlock />
+      <ul className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <li key={i} className="rounded-xl border border-panel-edge/60 bg-panel/40 p-5 md:p-6">
+            <Shimmer className="ml-auto h-9 w-9 rounded-full" />
+            <Shimmer className="mt-3 h-10 w-2/3" />
+            <Shimmer className="mt-3 h-3 w-1/2" />
+          </li>
+        ))}
+      </ul>
+      <div className="mt-12">
+        <Shimmer className="h-3 w-32" />
+        <div className="mt-4 flex flex-wrap gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Shimmer key={i} className="h-7 w-28 rounded-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ContactSkeleton() {
+  return (
+    <div className="relative mx-auto flex min-h-[70vh] max-w-5xl flex-col justify-center px-6 pt-28 pb-20 md:pt-36">
+      <Shimmer className="h-4 w-48" />
+      <Shimmer className="mt-5 h-14 w-4/5 md:h-20" />
+      <Shimmer className="mt-6 h-4 w-full" />
+      <Shimmer className="mt-2 h-4 w-3/4" />
+      <div className="mt-10 grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <GlassCard key={i} className="space-y-3">
+            <Shimmer className="h-3 w-16" />
+            <Shimmer className="h-5 w-3/4" />
+            <Shimmer className="h-3 w-1/2" />
+          </GlassCard>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const VARIANTS: Record<SkeletonVariant, () => ReactElement> = {
+  timeline: TimelineSkeleton,
+  skills: SkillsSkeleton,
+  projects: ProjectsSkeleton,
+  metrics: MetricsSkeleton,
+  contact: ContactSkeleton,
+}
+
+interface SectionSkeletonProps {
+  variant: SkeletonVariant
+  label: string
+}
+
+export default function SectionSkeleton({ variant, label }: SectionSkeletonProps) {
+  const Skeleton = VARIANTS[variant]
+  return (
+    <section
+      className="relative overflow-hidden"
+      role="status"
+      aria-label={`Loading ${label}`}
+      aria-busy="true"
+    >
+      <Skeleton />
+    </section>
+  )
+}

--- a/src/components/SkillsConstellation.tsx
+++ b/src/components/SkillsConstellation.tsx
@@ -65,7 +65,7 @@ function SkillChip({
         onClick={() => onSelect(skill)}
         aria-haspopup="dialog"
         aria-expanded={active}
-        className={`inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 font-mono text-xs transition-colors ${
+        className={`press-feedback inline-flex min-h-11 cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 font-mono text-xs transition-colors ${
           isCore ? 'border-panel-edge bg-panel text-ink' : 'border-panel-edge/60 text-ink-muted'
         } ${active ? 'ring-2 ring-offset-2 ring-offset-void' : ''}`}
         style={{
@@ -193,7 +193,7 @@ export default function SkillsConstellation() {
         <div
           ref={canvasRef}
           data-reveal
-          className="glass-panel relative mt-10 h-[420px] overflow-hidden rounded-2xl md:h-[540px]"
+          className="glass-panel relative mt-10 h-[320px] overflow-hidden rounded-2xl sm:h-[420px] md:h-[540px]"
         >
           {/* The 3D graph is a decorative enhancement — hidden from AT; the story
               panel below (when open) is real interactive content and stays exposed. */}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -83,8 +83,8 @@ h4 {
 .tilt-card {
   --mx: 50%;
   --my: 50%;
-  transform: perspective(900px) rotateX(var(--rx, 0deg)) rotateY(var(--ry, 0deg)) translateZ(0);
-  transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform: perspective(900px) rotateX(var(--rx, 0deg)) rotateY(var(--ry, 0deg)) translateZ(0) scale(var(--tilt-scale, 1));
+  transition: transform 0.35s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.25s ease, border-color 0.25s ease;
   will-change: transform;
 }
 .tilt-card::after {
@@ -100,9 +100,17 @@ h4 {
 .tilt-card:hover::after {
   opacity: 1;
 }
+/* Tactile press feedback — works on both desktop click and mobile tap.
+   On coarse pointers we skip the tilt transform entirely so only scale applies. */
+.tilt-card:active {
+  --tilt-scale: 0.985;
+}
 @media (pointer: coarse) {
   .tilt-card {
-    transform: none !important;
+    transform: scale(var(--tilt-scale, 1));
+  }
+  .tilt-card:active {
+    --tilt-scale: 0.98;
   }
 }
 
@@ -380,6 +388,14 @@ h4 {
 }
 .skip-link:focus {
   transform: translateY(0);
+}
+
+/* Tactile press feedback for buttons, chips, and menu links that don't use tilt-card. */
+.press-feedback {
+  transition: transform 0.15s var(--ease-out), box-shadow 0.25s ease, border-color 0.25s ease, color 0.2s ease;
+}
+.press-feedback:active {
+  transform: scale(0.96);
 }
 
 /* Themed skeleton shimmer — HUD-style moving gradient that signals activity

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -382,6 +382,34 @@ h4 {
   transform: translateY(0);
 }
 
+/* Themed skeleton shimmer — HUD-style moving gradient that signals activity
+   without the generic browser defaults. */
+.skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    rgba(91, 103, 128, 0.18) 0%,
+    rgba(91, 103, 128, 0.32) 45%,
+    rgba(34, 211, 238, 0.18) 55%,
+    rgba(91, 103, 128, 0.18) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer {
+    animation: none;
+    background: rgba(91, 103, 128, 0.22);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;


### PR DESCRIPTION
## What
Replaces the generic `loading…` text fallbacks with HUD-style, section-specific skeleton placeholders while lazy chunks stream in.

## Why
The previous `SectionFallback` broke the cinematic, structured feel of the page during chunk hydration. Themed skeletons preserve layout continuity and signal activity in a way that matches the portfolio's visual language.

## Changes
- Added `src/components/SectionSkeleton.tsx` with variants for `timeline`, `skills`, `projects`, `metrics`, and `contact`.
- Added `.skeleton-shimmer` keyframe animation in `src/styles/globals.css` with a cyan-accented moving gradient; disabled under `prefers-reduced-motion`.
- Updated `src/App.tsx` to render the matching skeleton variant for each `Suspense` boundary.
- Added `scripts/audit-screenshots.mjs` (local audit helper) to `.eslintignore` in `eslint.config.js`.

## Checklist
- [x] TypeScript passes (`npm run typecheck`)
- [x] No new lint errors in changed files
- [x] Respects `prefers-reduced-motion`
- [x] No content rewrites or framework changes

## Screenshots
Audit screenshots captured in `./audit-screenshots/` (not committed).